### PR TITLE
docs(readme): update release badge to v0.8.6 and stars to 258

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 
 <p align="center">
   <a href="https://jfrog.github.io/boost/"><img src="https://img.shields.io/badge/website-jfrog.github.io%2Fboost-36a13b?logo=googlechrome&logoColor=white" alt="Website"></a>
-  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/badge/release-v0.7.5-36a13b" alt="Release"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/badge/release-v0.8.6-36a13b" alt="Release"></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
   <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
   <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/badge/downloads-94k%2B-6f42c1" alt="Downloads: 94k+"></a>
-  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/badge/stars-234-yellow" alt="Stars: 234"></a><br>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/badge/stars-258-yellow" alt="Stars: 258"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
 </p>


### PR DESCRIPTION
## Summary
- Update the README release badge from `v0.7.5` to the latest release `v0.8.6`
- Update the README stars badge from `234` to `258`

## Test plan
- [x] Verified latest release via `gh release list --repo jfrog/boost`
- [x] Verified current star count via `gh api repos/jfrog/boost`
- [x] Confirm README badges render correctly on GitHub


Made with [Cursor](https://cursor.com)