### PR TITLE
docs(readme): add Boost comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ $ boost npm ci
 
 The agent sees the useful summary, not the scrollback. On failures, Boost keeps the failing test, compiler error, or stack frame that matters.
 
+## [How Boost is different](https://boost.jfrog.com/docs/en/why-boost/)
+
+| Capability | Boost | RTK | Headroom | Caveman |
+| --- | :---: | :---: | :---: | :---: |
+| Command output compression | ✓ | ✓ | ✓ | × |
+| Full-context and RAG compression | × | × | ✓ | × |
+| Assistant reply compression | × | × | × | ✓ |
+| Command output recovery | ✓ | ✓ | ✓ | × |
+| Versioned retrieval feedback | ✓ | × | × | × |
+| Auto-disable repeatedly retrieved filters | ✓ | × | × | × |
+| Published task success and cost A/B | ✓ | × | × | × |
+
 ## See your savings
 
 After wrapping commands, check how many tokens Boost kept out of your context window:

--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ The agent sees the useful summary, not the scrollback. On failures, Boost keeps 
 | Full-context and RAG compression | × | × | ✓ | × |
 | Assistant reply compression | × | × | × | ✓ |
 | Command output recovery | ✓ | ✓ | ✓ | × |
+| Native approval sees original executable | ✓ | × | — | — |
 | Versioned retrieval feedback | ✓ | × | × | × |
 | Auto-disable repeatedly retrieved filters | ✓ | × | × | × |
-| Published task success and cost A/B | ✓ | × | × | × |
+| End-to-end agent task + cost A/B | ✓ | × | × | × |
 
 ## See your savings
 


### PR DESCRIPTION
## Summary
- add a compact capability table comparing Boost with RTK, Headroom, and Caveman
- link the table heading to the full sourced comparison on the Boost website

## Test plan
- [x] Review the rendered Markdown structure
- [x] Run `git diff --check`

Made with [Cursor](https://cursor.com)