### PR TITLE
docs(readme): localize repo main page with language selector

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <strong>Tokens sparen. Kontext maximieren.</strong>
+  <strong>Tokens sparen. Agents präziser machen.</strong>
 </p>
 
 <p align="center">

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,182 @@
+<p align="center">
+  <a href="https://boost.jfrog.com/">
+    <picture>
+      <source srcset=".github/assets/boost-logo-dark.png" media="(prefers-color-scheme: dark)">
+      <source srcset=".github/assets/boost-logo-light.png" media="(prefers-color-scheme: light)">
+      <img src=".github/assets/boost-logo-light.png" alt="Boost" width="260">
+    </picture>
+  </a>
+</p>
+
+<p align="center">
+  <strong>Tokens sparen. Kontext maximieren.</strong>
+</p>
+
+<p align="center">
+  <sub>Intelligente Token-Einsparungen für Coding-Agents und Shell-Befehle.</sub>
+</p>
+
+<p align="center">
+  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
+  <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+</p>
+
+<p align="center">
+  <sub>Gesponsert von <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <strong>Deutsch</strong> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.he.md">עברית</a>
+</p>
+
+---
+
+<p align="center">
+  <strong>Frogi, unser Maskottchen, erscheint, wenn du nur <code>boost</code> ausführst.</strong>
+</p>
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+  </picture>
+</p>
+
+**Boost** umschließt die Befehle, die deine Agents bereits ausführen, und verwandelt laute Logs in kompakten, strukturierten Kontext, der das Signal behält — Fehler, Zeiten, Änderungszählungen, Cache-Treffer — und gleichzeitig das Rauschen reduziert.
+
+Boost opfert nie Qualität für Einsparungen. Es entfernt nur, was sicher weggelassen werden kann, sodass die Agent-Ausgabe ebenso präzise bleibt. Unser [Terminal-Bench-2.0-Benchmark](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) zeigt es: identische Erfolgsrate bei Aufgaben, ~12 % niedrigere Kosten — Boost hält Agents optimiert, ohne ihren Takt zu unterbrechen.
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+  </picture>
+</p>
+
+## Schnellstart
+
+**Boost installieren**
+
+macOS / Linux / Windows WSL:
+
+```bash
+curl -fsSL https://boost.jfrog.com/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://boost.jfrog.com/install.ps1 | iex
+```
+
+**In Cursor, Claude Code, GitHub Copilot und Codex CLI einbinden:**
+
+```bash
+boost init
+```
+
+Für KI-Coding-Agents, die Boost auf dem Rechner eines Nutzers installieren, folge **[AGENT-INSTALL.md](./AGENT-INSTALL.md)**.
+
+## Wann du Boost nutzen solltest
+
+- **Lange Coding-Agent-Sitzungen** — Halte den Kontext über Dutzende von Shell-Befehlen schlank, damit Agents Tokens für die Aufgabe ausgeben, nicht für die Scrollback-Historie.
+- **Laute Test-, Build- und Debug-Schleifen** — Komprimiere `npm test`, `pytest`, `go test`, `docker build`, Linter und Logs und behalte dabei Fehlschläge und Zusammenfassungen.
+- **CI-Pipelines** — Kürzere, leichter zu überblickende Job-Logs mit Timing- und Cache-Signalen für GitHub Actions und andere Runner.
+- **Eigene oder interne Tools** — Füge TOML-Filter für deine eigenen CLIs hinzu, damit dieselbe Kompressionsschleife die Tools abdeckt, die deine Agents tatsächlich ausführen.
+
+## Intelligente Token-Einsparungen
+
+Boost kürzt die Ausgabe nicht einfach ab. Es wendet befehlsspezifische Filter an, die bewahren, was Agents brauchen, um über das Ergebnis nachzudenken.
+
+```bash
+# Without Boost: ~9,800 tokens of install noise
+$ npm ci
+npm warn deprecated inflight@1.0.6 / rimraf@3.0.2 / glob@7.2.3 …
+added 1285 packages, audited 1286 in 45s
+found 0 vulnerabilities
+
+# With Boost: ~640 tokens, same outcome, cache-backed
+$ boost npm ci
+[OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
+```
+
+Der Agent sieht die nützliche Zusammenfassung, nicht die Scrollback-Historie. Bei Fehlschlägen behält Boost den fehlgeschlagenen Test, den Compilerfehler oder den Stack-Frame, der zählt.
+
+## [Wie Boost anders ist](https://boost.jfrog.com/docs/en/why-boost/)
+
+| Fähigkeit | Boost | RTK | Headroom | Caveman |
+| --- | :---: | :---: | :---: | :---: |
+| Kompression der Befehlsausgabe | ✓ | ✓ | ✓ | × |
+| Vollkontext- und RAG-Kompression | × | × | ✓ | × |
+| Kompression der Assistentenantworten | × | × | × | ✓ |
+| Wiederherstellung der Befehlsausgabe | ✓ | ✓ | ✓ | × |
+| Native Freigabe sieht die Original-Executable | ✓ | × | — | — |
+| Versioniertes Retrieval-Feedback | ✓ | × | × | × |
+| Automatisches Deaktivieren wiederholt abgerufener Filter | ✓ | × | × | × |
+| End-to-End-A/B zu Agent-Aufgabe + Kosten | ✓ | × | × | × |
+
+## Sieh deine Einsparungen
+
+Nach dem Umschließen von Befehlen öffne den interaktiven Web-Report:
+
+```bash
+boost report
+```
+
+Für eine narrative Zusammenfassung im Terminal:
+
+```bash
+boost report -t
+# or: boost report --tui
+```
+
+## Was es umschließt
+
+- **Agents:** Cursor, Claude Code, GitHub Copilot, Codex CLI.
+- **Befehle:** Docker, npm, pytest, Git, GitHub CLI und andere Shell-Befehle laufen durch denselben Wrapper.
+
+## Wie deine Agents Boost nutzen
+
+- `boost docker build ...` — komprimiertes Build-Log und Layer-Cache-Zusammenfassung
+- `boost npm ci` — Abhängigkeitszusammenfassung, lokaler Paket-Cache, retry-sichere Ausgabe
+- `boost pytest` — ruhige Ausgabe bei grünen Läufen, nützliche Fehlschläge wenn Tests scheitern
+
+## Aktualisieren
+
+```bash
+boost update
+```
+
+## Dokumentation
+
+Siehe die [vollständige Dokumentation](https://boost.jfrog.com/docs/en/overview/) zu Befehlen, Konfiguration und OpenTelemetry-Export.
+
+## Sicherheit & Datenschutz
+
+- **Local-first.** Befehlsverlauf und Rohprotokolle bleiben auf deinem Rechner.
+- **Nur Metadaten verlassen das System.** Wenn Boost Nutzungsdaten sendet, gehen sie nur an JFrog, um das Produkt zu verbessern. Exportierte Metadaten umfassen Timing, Exit-Code und Cache-Statistiken — niemals Rohprotokolle, Dateiinhalte oder Umgebungsvariablen. Secrets, die auf Muster wie `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` passen, werden vor dem Schreiben oder Export redigiert.
+- **Offenes Protokoll, signierte Binaries.** OpenTelemetry-nativ. Binaries werden über GitHub Releases signiert ausgeliefert.
+
+Vollständige Richtlinie, unterstützte Versionen und wie du eine Schwachstelle meldest: siehe [SECURITY.md](./SECURITY.md).
+
+## Lizenz
+
+Copyright © 2026 JFrog Ltd. Alle Rechte vorbehalten. Siehe [LICENSE](LICENSE) und [BETA_AGREEMENT.md](BETA_AGREEMENT.md).
+
+---
+
+*Gewidmet dem Andenken an Dima Gershovich — ein brillanter Ingenieur, ein talentierter Musiker und ein lieber Freund.* [Lies Dimas Geschichte](docs/memorial/MEMORIAL.md)

--- a/README.de.md
+++ b/README.de.md
@@ -20,10 +20,10 @@
   <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
   <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
-  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Plattformen">
   <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
-  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
-  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="GitHub-Sterne"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-nativ">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
 </p>
 
@@ -51,19 +51,19 @@
   <picture>
     <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, das Boost-Maskottchen" width="180">
   </picture>
 </p>
 
-**Boost** umschließt die Befehle, die deine Agents bereits ausführen, und verwandelt laute Logs in kompakten, strukturierten Kontext, der das Signal behält — Fehler, Zeiten, Änderungszählungen, Cache-Treffer — und gleichzeitig das Rauschen reduziert.
+**Boost** versieht die Befehle, die deine Agents bereits ausführen, mit einem Wrapper und verwandelt unübersichtliche Logs in kompakten, strukturierten Kontext. Dabei bleiben die relevanten Informationen — Fehler, Laufzeiten, die Anzahl der Änderungen und Cache-Treffer — erhalten, während das Rauschen reduziert wird.
 
-Boost opfert nie Qualität für Einsparungen. Es entfernt nur, was sicher weggelassen werden kann, sodass die Agent-Ausgabe ebenso präzise bleibt. Unser [Terminal-Bench-2.0-Benchmark](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) zeigt es: identische Erfolgsrate bei Aufgaben, ~12 % niedrigere Kosten — Boost hält Agents optimiert, ohne ihren Takt zu unterbrechen.
+Boost spart nie auf Kosten der Qualität. Es kürzt nur Inhalte, die bedenkenlos entfallen können, sodass die Agent-Ausgabe genauso präzise bleibt. Unser [Terminal-Bench-2.0-Benchmark](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) belegt das: identische Erfolgsquote bei der Aufgabenbearbeitung, ~12 % niedrigere Kosten — Boost sorgt dafür, dass Agents effizient arbeiten, ohne ihren Arbeitsfluss zu unterbrechen.
 
 <p align="center">
   <picture>
     <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost verwenden: installieren, boost init, eine Aufgabe ausführen, boost report" width="768">
   </picture>
 </p>
 
@@ -71,7 +71,7 @@ Boost opfert nie Qualität für Einsparungen. Es entfernt nur, was sicher weggel
 
 **Boost installieren**
 
-macOS / Linux / Windows WSL:
+macOS / Linux / Windows mit WSL:
 
 ```bash
 curl -fsSL https://boost.jfrog.com/install.sh | bash
@@ -89,18 +89,18 @@ irm https://boost.jfrog.com/install.ps1 | iex
 boost init
 ```
 
-Für KI-Coding-Agents, die Boost auf dem Rechner eines Nutzers installieren, folge **[AGENT-INSTALL.md](./AGENT-INSTALL.md)**.
+KI-Coding-Agents, die Boost auf dem Rechner eines Nutzers installieren, sollten die Anweisungen in **[AGENT-INSTALL.md](./AGENT-INSTALL.md)** befolgen.
 
 ## Wann du Boost nutzen solltest
 
-- **Lange Coding-Agent-Sitzungen** — Halte den Kontext über Dutzende von Shell-Befehlen schlank, damit Agents Tokens für die Aufgabe ausgeben, nicht für die Scrollback-Historie.
-- **Laute Test-, Build- und Debug-Schleifen** — Komprimiere `npm test`, `pytest`, `go test`, `docker build`, Linter und Logs und behalte dabei Fehlschläge und Zusammenfassungen.
-- **CI-Pipelines** — Kürzere, leichter zu überblickende Job-Logs mit Timing- und Cache-Signalen für GitHub Actions und andere Runner.
-- **Eigene oder interne Tools** — Füge TOML-Filter für deine eigenen CLIs hinzu, damit dieselbe Kompressionsschleife die Tools abdeckt, die deine Agents tatsächlich ausführen.
+- **Lange Coding-Agent-Sitzungen** — Halte den Kontext über Dutzende von Shell-Befehlen hinweg schlank, damit Agents ihre Tokens für die Aufgabe statt für den Scrollback aufwenden.
+- **Test-, Build- und Debug-Schleifen mit umfangreicher Ausgabe** — Komprimiere `npm test`, `pytest`, `go test`, `docker build`, Linter und Logs, wobei Fehler und Zusammenfassungen erhalten bleiben.
+- **CI-Pipelines** — Kürzere, leichter zu überblickende Job-Logs mit Laufzeit- und Cache-Informationen für GitHub Actions und andere Runner.
+- **Eigene oder interne Tools** — Füge TOML-Filter für deine eigenen CLIs hinzu, damit dieselbe Komprimierungslogik auch die Tools abdeckt, die deine Agents tatsächlich ausführen.
 
 ## Intelligente Token-Einsparungen
 
-Boost kürzt die Ausgabe nicht einfach ab. Es wendet befehlsspezifische Filter an, die bewahren, was Agents brauchen, um über das Ergebnis nachzudenken.
+Boost kürzt die Ausgabe nicht einfach ab. Es wendet befehlsspezifische Filter an, die alles bewahren, was Agents benötigen, um das Ergebnis auszuwerten.
 
 ```bash
 # Without Boost: ~9,800 tokens of install noise
@@ -114,46 +114,46 @@ $ boost npm ci
 [OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
 ```
 
-Der Agent sieht die nützliche Zusammenfassung, nicht die Scrollback-Historie. Bei Fehlschlägen behält Boost den fehlgeschlagenen Test, den Compilerfehler oder den Stack-Frame, der zählt.
+Der Agent sieht die nützliche Zusammenfassung statt des Scrollbacks. Im Fehlerfall lässt Boost den entscheidenden fehlgeschlagenen Test, Compilerfehler oder Stack-Frame in der Ausgabe stehen.
 
-## [Wie Boost anders ist](https://boost.jfrog.com/docs/en/why-boost/)
+## [Was Boost von anderen unterscheidet](https://boost.jfrog.com/docs/en/why-boost/)
 
 | Fähigkeit | Boost | RTK | Headroom | Caveman |
 | --- | :---: | :---: | :---: | :---: |
 | Kompression der Befehlsausgabe | ✓ | ✓ | ✓ | × |
-| Vollkontext- und RAG-Kompression | × | × | ✓ | × |
+| Kompression des vollständigen Kontexts und RAG-Kompression | × | × | ✓ | × |
 | Kompression der Assistentenantworten | × | × | × | ✓ |
 | Wiederherstellung der Befehlsausgabe | ✓ | ✓ | ✓ | × |
-| Native Freigabe sieht die Original-Executable | ✓ | × | — | — |
+| Ursprüngliche ausführbare Datei für native Freigabe sichtbar | ✓ | × | — | — |
 | Versioniertes Retrieval-Feedback | ✓ | × | × | × |
-| Automatisches Deaktivieren wiederholt abgerufener Filter | ✓ | × | × | × |
-| End-to-End-A/B zu Agent-Aufgabe + Kosten | ✓ | × | × | × |
+| Automatische Deaktivierung von Filtern nach wiederholtem Abruf der Originalausgabe | ✓ | × | × | × |
+| Durchgängiger A/B-Test von Agent-Aufgaben und Kosten | ✓ | × | × | × |
 
-## Sieh deine Einsparungen
+## Sieh dir deine Einsparungen an
 
-Nach dem Umschließen von Befehlen öffne den interaktiven Web-Report:
+Sobald deine Befehle über Boost laufen, öffne den interaktiven Webbericht:
 
 ```bash
 boost report
 ```
 
-Für eine narrative Zusammenfassung im Terminal:
+Für eine ausformulierte Zusammenfassung im Terminal:
 
 ```bash
 boost report -t
 # or: boost report --tui
 ```
 
-## Was es umschließt
+## Welche Agents und Befehle Boost abdeckt
 
 - **Agents:** Cursor, Claude Code, GitHub Copilot, Codex CLI.
 - **Befehle:** Docker, npm, pytest, Git, GitHub CLI und andere Shell-Befehle laufen durch denselben Wrapper.
 
 ## Wie deine Agents Boost nutzen
 
-- `boost docker build ...` — komprimiertes Build-Log und Layer-Cache-Zusammenfassung
-- `boost npm ci` — Abhängigkeitszusammenfassung, lokaler Paket-Cache, retry-sichere Ausgabe
-- `boost pytest` — ruhige Ausgabe bei grünen Läufen, nützliche Fehlschläge wenn Tests scheitern
+- `boost docker build ...` — komprimiertes Build-Log und Zusammenfassung des Layer-Caches
+- `boost npm ci` — Abhängigkeitszusammenfassung, lokaler Paket-Cache, zuverlässige Ausgabe auch bei Wiederholungsversuchen
+- `boost pytest` — knappe Ausgabe bei erfolgreichen Testläufen, aussagekräftige Fehlerinformationen, wenn Tests scheitern
 
 ## Aktualisieren
 
@@ -168,10 +168,10 @@ Siehe die [vollständige Dokumentation](https://boost.jfrog.com/docs/en/overview
 ## Sicherheit & Datenschutz
 
 - **Local-first.** Befehlsverlauf und Rohprotokolle bleiben auf deinem Rechner.
-- **Nur Metadaten verlassen das System.** Wenn Boost Nutzungsdaten sendet, gehen sie nur an JFrog, um das Produkt zu verbessern. Exportierte Metadaten umfassen Timing, Exit-Code und Cache-Statistiken — niemals Rohprotokolle, Dateiinhalte oder Umgebungsvariablen. Secrets, die auf Muster wie `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` passen, werden vor dem Schreiben oder Export redigiert.
-- **Offenes Protokoll, signierte Binaries.** OpenTelemetry-nativ. Binaries werden über GitHub Releases signiert ausgeliefert.
+- **Nur Metadaten werden übertragen.** Wenn Boost Nutzungsdaten sendet, gehen sie ausschließlich an JFrog, um das Produkt zu verbessern. Exportierte Metadaten umfassen Laufzeitinformationen, Exit-Code und Cache-Statistiken, niemals jedoch Rohprotokolle, Dateiinhalte oder Werte von Umgebungsvariablen. Secrets, die Mustern wie `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` entsprechen, werden vor dem Speichern oder Exportieren unkenntlich gemacht.
+- **Offenes Protokoll, signierte Binärdateien.** OpenTelemetry-nativ. Signierte Binärdateien werden über GitHub Releases ausgeliefert.
 
-Vollständige Richtlinie, unterstützte Versionen und wie du eine Schwachstelle meldest: siehe [SECURITY.md](./SECURITY.md).
+Die vollständige Richtlinie, Angaben zu unterstützten Versionen und eine Anleitung zum Melden einer Schwachstelle findest du in [SECURITY.md](./SECURITY.md).
 
 ## Lizenz
 
@@ -179,4 +179,4 @@ Copyright © 2026 JFrog Ltd. Alle Rechte vorbehalten. Siehe [LICENSE](LICENSE) u
 
 ---
 
-*Gewidmet dem Andenken an Dima Gershovich — ein brillanter Ingenieur, ein talentierter Musiker und ein lieber Freund.* [Lies Dimas Geschichte](docs/memorial/MEMORIAL.md)
+*In Erinnerung an Dima Gershovich — einen brillanten Ingenieur, talentierten Musiker und lieben Freund.* [Lies Dimas Geschichte](docs/memorial/MEMORIAL.md)

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,182 @@
+<p align="center">
+  <a href="https://boost.jfrog.com/">
+    <picture>
+      <source srcset=".github/assets/boost-logo-dark.png" media="(prefers-color-scheme: dark)">
+      <source srcset=".github/assets/boost-logo-light.png" media="(prefers-color-scheme: light)">
+      <img src=".github/assets/boost-logo-light.png" alt="Boost" width="260">
+    </picture>
+  </a>
+</p>
+
+<p align="center">
+  <strong>Ahorra tokens. Maximiza el contexto.</strong>
+</p>
+
+<p align="center">
+  <sub>Ahorro inteligente de tokens para agentes de codificación y comandos de shell.</sub>
+</p>
+
+<p align="center">
+  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
+  <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+</p>
+
+<p align="center">
+  <sub>Patrocinado por <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <strong>Español</strong> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.he.md">עברית</a>
+</p>
+
+---
+
+<p align="center">
+  <strong>Frogi, nuestra mascota, aparece cuando ejecutas solo <code>boost</code>.</strong>
+</p>
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+  </picture>
+</p>
+
+**Boost** envuelve los comandos que tus agentes ya ejecutan, convirtiendo logs ruidosos en contexto compacto y estructurado que conserva la señal — errores, tiempos, conteos de cambios, aciertos de caché — mientras reduce el ruido.
+
+Boost nunca sacrifica calidad por ahorro. Solo recorta lo que es seguro eliminar, para que la salida del agente siga siendo igual de precisa. Nuestro [benchmark Terminal-Bench 2.0](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) lo demuestra: la misma tasa de éxito en las tareas, ~12 % menos de coste — Boost mantiene a los agentes optimizados sin frenar su ritmo.
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+  </picture>
+</p>
+
+## Inicio rápido
+
+**Instalar Boost**
+
+macOS / Linux / Windows WSL:
+
+```bash
+curl -fsSL https://boost.jfrog.com/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://boost.jfrog.com/install.ps1 | iex
+```
+
+**Conéctalo a Cursor, Claude Code, GitHub Copilot y Codex CLI:**
+
+```bash
+boost init
+```
+
+Para agentes de codificación con IA que instalen Boost en la máquina de un usuario, sigue **[AGENT-INSTALL.md](./AGENT-INSTALL.md)**.
+
+## Cuándo usar Boost
+
+- **Sesiones largas de agentes de codificación** — Mantén el contexto ágil a lo largo de docenas de comandos de shell para que los agentes gasten tokens en la tarea, no en el scrollback.
+- **Bucles ruidosos de test, build y debug** — Comprime `npm test`, `pytest`, `go test`, `docker build`, linters y logs, conservando fallos y resúmenes.
+- **Pipelines de CI** — Logs de jobs más cortos y fáciles de escanear, con señales de tiempo y de caché para GitHub Actions y otros runners.
+- **Herramientas personalizadas o internas** — Añade filtros TOML para tus propios CLIs y así el mismo bucle de compresión cubre las herramientas que tus agentes realmente usan.
+
+## Ahorro inteligente de tokens
+
+Boost no se limita a truncar la salida. Aplica filtros conscientes del comando que preservan lo que los agentes necesitan para razonar sobre el resultado.
+
+```bash
+# Without Boost: ~9,800 tokens of install noise
+$ npm ci
+npm warn deprecated inflight@1.0.6 / rimraf@3.0.2 / glob@7.2.3 …
+added 1285 packages, audited 1286 in 45s
+found 0 vulnerabilities
+
+# With Boost: ~640 tokens, same outcome, cache-backed
+$ boost npm ci
+[OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
+```
+
+El agente ve el resumen útil, no el scrollback. En caso de fallo, Boost conserva el test fallido, el error del compilador o el frame de stack que importa.
+
+## [Cómo se diferencia Boost](https://boost.jfrog.com/docs/en/why-boost/)
+
+| Capacidad | Boost | RTK | Headroom | Caveman |
+| --- | :---: | :---: | :---: | :---: |
+| Compresión de salida de comandos | ✓ | ✓ | ✓ | × |
+| Compresión de contexto completo y RAG | × | × | ✓ | × |
+| Compresión de respuestas del asistente | × | × | × | ✓ |
+| Recuperación de salida de comandos | ✓ | ✓ | ✓ | × |
+| La aprobación nativa ve el ejecutable original | ✓ | × | — | — |
+| Feedback de recuperación versionado | ✓ | × | × | × |
+| Desactivar automáticamente filtros recuperados de forma repetida | ✓ | × | × | × |
+| A/B de tarea de agente + coste de extremo a extremo | ✓ | × | × | × |
+
+## Consulta tus ahorros
+
+Tras envolver comandos, abre el informe web interactivo:
+
+```bash
+boost report
+```
+
+Para un resumen narrativo en la terminal:
+
+```bash
+boost report -t
+# or: boost report --tui
+```
+
+## Qué envuelve
+
+- **Agentes:** Cursor, Claude Code, GitHub Copilot, Codex CLI.
+- **Comandos:** Docker, npm, pytest, Git, GitHub CLI y otros comandos de shell pasan por el mismo wrapper.
+
+## Cómo usan Boost tus agentes
+
+- `boost docker build ...` — log de build comprimido y resumen de caché de capas
+- `boost npm ci` — resumen de dependencias, caché local de paquetes, salida segura para reintentos
+- `boost pytest` — salida silenciosa en ejecuciones en verde, fallos útiles cuando fallan los tests
+
+## Actualizar
+
+```bash
+boost update
+```
+
+## Documentación
+
+Consulta la [documentación completa](https://boost.jfrog.com/docs/en/overview/) para comandos, configuración y exportación OpenTelemetry.
+
+## Seguridad y privacidad
+
+- **Local primero.** El historial de comandos y los logs en bruto permanecen en tu máquina.
+- **Solo salen metadatos.** Cuando Boost envía datos de uso, van únicamente a JFrog para ayudar a mejorar el producto. Los metadatos exportados incluyen tiempos, código de salida y estadísticas de caché; nunca logs en bruto, contenido de archivos ni valores de entorno. Los secretos que coinciden con patrones como `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` se redactan antes de escribir o exportar.
+- **Protocolo abierto, binarios firmados.** Nativo de OpenTelemetry. Los binarios se publican firmados a través de GitHub Releases.
+
+Política completa, versiones compatibles y cómo informar de una vulnerabilidad: consulta [SECURITY.md](./SECURITY.md).
+
+## Licencia
+
+Copyright © 2026 JFrog Ltd. Todos los derechos reservados. Consulta [LICENSE](LICENSE) y [BETA_AGREEMENT.md](BETA_AGREEMENT.md).
+
+---
+
+*Dedicado a la memoria de Dima Gershovich — un ingeniero brillante, un músico talentoso y un querido amigo.* [Lee la historia de Dima](docs/memorial/MEMORIAL.md)

--- a/README.es.md
+++ b/README.es.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <strong>Ahorra tokens. Aprovecha al máximo el contexto.</strong>
+  <strong>Ahorra tokens. Mejora la precisión de tus agentes.</strong>
 </p>
 
 <p align="center">

--- a/README.es.md
+++ b/README.es.md
@@ -9,21 +9,21 @@
 </p>
 
 <p align="center">
-  <strong>Ahorra tokens. Maximiza el contexto.</strong>
+  <strong>Ahorra tokens. Aprovecha al máximo el contexto.</strong>
 </p>
 
 <p align="center">
-  <sub>Ahorro inteligente de tokens para agentes de codificación y comandos de shell.</sub>
+  <sub>Ahorro inteligente de tokens para agentes de programación y comandos de shell.</sub>
 </p>
 
 <p align="center">
-  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
-  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
+  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Sitio web"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Versión"></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
-  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
-  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
-  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
-  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Plataformas">
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Descargas"></a>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Estrellas"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Nativo para agentes">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
 </p>
 
@@ -44,26 +44,26 @@
 ---
 
 <p align="center">
-  <strong>Frogi, nuestra mascota, aparece cuando ejecutas solo <code>boost</code>.</strong>
+  <strong>Frogi, nuestra mascota, aparece cuando ejecutas únicamente <code>boost</code>.</strong>
 </p>
 
 <p align="center">
   <picture>
     <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, la mascota de Boost" width="180">
   </picture>
 </p>
 
-**Boost** envuelve los comandos que tus agentes ya ejecutan, convirtiendo logs ruidosos en contexto compacto y estructurado que conserva la señal — errores, tiempos, conteos de cambios, aciertos de caché — mientras reduce el ruido.
+**Boost** actúa como una capa sobre los comandos que tus agentes ya ejecutan y convierte registros con mucho ruido en un contexto compacto y estructurado que conserva la señal —errores, tiempos, recuentos de cambios y aciertos de caché— mientras reduce el ruido.
 
-Boost nunca sacrifica calidad por ahorro. Solo recorta lo que es seguro eliminar, para que la salida del agente siga siendo igual de precisa. Nuestro [benchmark Terminal-Bench 2.0](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) lo demuestra: la misma tasa de éxito en las tareas, ~12 % menos de coste — Boost mantiene a los agentes optimizados sin frenar su ritmo.
+Boost nunca sacrifica calidad para ahorrar. Solo elimina lo que puede descartarse sin riesgo, por lo que la salida del agente conserva la misma precisión. Nuestra [evaluación comparativa con Terminal-Bench 2.0](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) lo demuestra: la misma tasa de éxito en las tareas con un coste aproximadamente un 12 % inferior. Boost mantiene optimizados a los agentes sin interrumpir nunca su ritmo.
 
 <p align="center">
   <picture>
     <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="Cómo usar Boost: instalar, boost init, ejecutar una tarea, boost report" width="768">
   </picture>
 </p>
 
@@ -83,24 +83,24 @@ Windows PowerShell:
 irm https://boost.jfrog.com/install.ps1 | iex
 ```
 
-**Conéctalo a Cursor, Claude Code, GitHub Copilot y Codex CLI:**
+**Intégralo en Cursor, Claude Code, GitHub Copilot y Codex CLI:**
 
 ```bash
 boost init
 ```
 
-Para agentes de codificación con IA que instalen Boost en la máquina de un usuario, sigue **[AGENT-INSTALL.md](./AGENT-INSTALL.md)**.
+Los agentes de programación con IA que instalen Boost en el equipo de un usuario deben seguir **[AGENT-INSTALL.md](./AGENT-INSTALL.md)**.
 
 ## Cuándo usar Boost
 
-- **Sesiones largas de agentes de codificación** — Mantén el contexto ágil a lo largo de docenas de comandos de shell para que los agentes gasten tokens en la tarea, no en el scrollback.
-- **Bucles ruidosos de test, build y debug** — Comprime `npm test`, `pytest`, `go test`, `docker build`, linters y logs, conservando fallos y resúmenes.
-- **Pipelines de CI** — Logs de jobs más cortos y fáciles de escanear, con señales de tiempo y de caché para GitHub Actions y otros runners.
-- **Herramientas personalizadas o internas** — Añade filtros TOML para tus propios CLIs y así el mismo bucle de compresión cubre las herramientas que tus agentes realmente usan.
+- **Sesiones largas con agentes de programación** — Mantén un contexto compacto durante docenas de comandos de shell para que los agentes dediquen los tokens a la tarea y no al historial de la terminal.
+- **Ciclos ruidosos de pruebas, compilación y depuración** — Comprime `npm test`, `pytest`, `go test`, `docker build`, linters y registros, pero conserva los fallos y los resúmenes.
+- **Pipelines de CI** — Registros de trabajos más breves y fáciles de revisar, con información sobre tiempos y caché para GitHub Actions y otros ejecutores.
+- **Herramientas personalizadas o internas** — Añade filtros TOML para tus propias CLI, de modo que el mismo ciclo de compresión cubra las herramientas que tus agentes utilizan realmente.
 
 ## Ahorro inteligente de tokens
 
-Boost no se limita a truncar la salida. Aplica filtros conscientes del comando que preservan lo que los agentes necesitan para razonar sobre el resultado.
+Boost no se limita a truncar la salida. Aplica filtros que tienen en cuenta el comando y conservan lo que los agentes necesitan para razonar sobre el resultado.
 
 ```bash
 # Without Boost: ~9,800 tokens of install noise
@@ -114,24 +114,24 @@ $ boost npm ci
 [OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
 ```
 
-El agente ve el resumen útil, no el scrollback. En caso de fallo, Boost conserva el test fallido, el error del compilador o el frame de stack que importa.
+El agente ve el resumen útil, no todo el historial de la terminal. Cuando se produce un fallo, Boost conserva la prueba fallida, el error del compilador o el marco de pila relevante.
 
-## [Cómo se diferencia Boost](https://boost.jfrog.com/docs/en/why-boost/)
+## [En qué se diferencia Boost](https://boost.jfrog.com/docs/en/why-boost/)
 
 | Capacidad | Boost | RTK | Headroom | Caveman |
 | --- | :---: | :---: | :---: | :---: |
-| Compresión de salida de comandos | ✓ | ✓ | ✓ | × |
-| Compresión de contexto completo y RAG | × | × | ✓ | × |
-| Compresión de respuestas del asistente | × | × | × | ✓ |
-| Recuperación de salida de comandos | ✓ | ✓ | ✓ | × |
-| La aprobación nativa ve el ejecutable original | ✓ | × | — | — |
-| Feedback de recuperación versionado | ✓ | × | × | × |
-| Desactivar automáticamente filtros recuperados de forma repetida | ✓ | × | × | × |
-| A/B de tarea de agente + coste de extremo a extremo | ✓ | × | × | × |
+| Compresión de la salida de comandos | ✓ | ✓ | ✓ | × |
+| Compresión del contexto completo y compresión RAG | × | × | ✓ | × |
+| Compresión de las respuestas del asistente | × | × | × | ✓ |
+| Recuperación de la salida de comandos | ✓ | ✓ | ✓ | × |
+| El sistema de aprobación nativo recibe el ejecutable original | ✓ | × | — | — |
+| Información versionada sobre las recuperaciones | ✓ | × | × | × |
+| Desactivación automática de filtros cuyo contenido se recupera repetidamente | ✓ | × | × | × |
+| Pruebas A/B integrales de tareas y costes de agentes | ✓ | × | × | × |
 
 ## Consulta tus ahorros
 
-Tras envolver comandos, abre el informe web interactivo:
+Una vez que hayas ejecutado comandos a través de Boost, abre el informe web interactivo:
 
 ```bash
 boost report
@@ -144,16 +144,16 @@ boost report -t
 # or: boost report --tui
 ```
 
-## Qué envuelve
+## Qué cubre
 
 - **Agentes:** Cursor, Claude Code, GitHub Copilot, Codex CLI.
-- **Comandos:** Docker, npm, pytest, Git, GitHub CLI y otros comandos de shell pasan por el mismo wrapper.
+- **Comandos:** Docker, npm, pytest, Git, GitHub CLI y otros comandos de shell se ejecutan a través de la misma capa de Boost.
 
 ## Cómo usan Boost tus agentes
 
-- `boost docker build ...` — log de build comprimido y resumen de caché de capas
-- `boost npm ci` — resumen de dependencias, caché local de paquetes, salida segura para reintentos
-- `boost pytest` — salida silenciosa en ejecuciones en verde, fallos útiles cuando fallan los tests
+- `boost docker build ...` — registro de compilación comprimido y resumen de la caché de capas
+- `boost npm ci` — resumen de dependencias, caché local de paquetes, salida que permite reintentos seguros
+- `boost pytest` — salida mínima cuando las pruebas terminan correctamente y detalles útiles cuando fallan
 
 ## Actualizar
 
@@ -163,15 +163,15 @@ boost update
 
 ## Documentación
 
-Consulta la [documentación completa](https://boost.jfrog.com/docs/en/overview/) para comandos, configuración y exportación OpenTelemetry.
+Consulta la [documentación completa](https://boost.jfrog.com/docs/en/overview/) para obtener información sobre los comandos, la configuración y la exportación mediante OpenTelemetry.
 
 ## Seguridad y privacidad
 
-- **Local primero.** El historial de comandos y los logs en bruto permanecen en tu máquina.
-- **Solo salen metadatos.** Cuando Boost envía datos de uso, van únicamente a JFrog para ayudar a mejorar el producto. Los metadatos exportados incluyen tiempos, código de salida y estadísticas de caché; nunca logs en bruto, contenido de archivos ni valores de entorno. Los secretos que coinciden con patrones como `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` se redactan antes de escribir o exportar.
-- **Protocolo abierto, binarios firmados.** Nativo de OpenTelemetry. Los binarios se publican firmados a través de GitHub Releases.
+- **Prioridad al entorno local.** El historial de comandos y los registros sin procesar permanecen en tu equipo.
+- **Solo salen metadatos.** Cuando Boost envía datos de uso, van únicamente a JFrog para ayudar a mejorar el producto. Los metadatos exportados incluyen información sobre tiempos, el código de salida y estadísticas de caché, pero nunca registros sin procesar, contenido de archivos ni valores de variables de entorno. Los secretos que coinciden con patrones como `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` se ocultan antes de almacenarlos o exportarlos.
+- **Protocolo abierto, binarios firmados.** Compatible de forma nativa con OpenTelemetry. Los binarios se distribuyen firmados a través de GitHub Releases.
 
-Política completa, versiones compatibles y cómo informar de una vulnerabilidad: consulta [SECURITY.md](./SECURITY.md).
+Consulta [SECURITY.md](./SECURITY.md) para conocer la política completa, las versiones compatibles y cómo informar de una vulnerabilidad.
 
 ## Licencia
 
@@ -179,4 +179,4 @@ Copyright © 2026 JFrog Ltd. Todos los derechos reservados. Consulta [LICENSE](L
 
 ---
 
-*Dedicado a la memoria de Dima Gershovich — un ingeniero brillante, un músico talentoso y un querido amigo.* [Lee la historia de Dima](docs/memorial/MEMORIAL.md)
+*Dedicado a la memoria de Dima Gershovich, un ingeniero brillante, un músico de gran talento y un amigo muy querido.* [Lee la historia de Dima](docs/memorial/MEMORIAL.md)

--- a/README.fr.md
+++ b/README.fr.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <strong>Économisez des tokens. Maximisez le contexte.</strong>
+  <strong>Économisez des tokens. Rendez vos agents plus précis.</strong>
 </p>
 
 <p align="center">

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,182 @@
+<p align="center">
+  <a href="https://boost.jfrog.com/">
+    <picture>
+      <source srcset=".github/assets/boost-logo-dark.png" media="(prefers-color-scheme: dark)">
+      <source srcset=".github/assets/boost-logo-light.png" media="(prefers-color-scheme: light)">
+      <img src=".github/assets/boost-logo-light.png" alt="Boost" width="260">
+    </picture>
+  </a>
+</p>
+
+<p align="center">
+  <strong>Économisez des tokens. Maximisez le contexte.</strong>
+</p>
+
+<p align="center">
+  <sub>Économies de tokens intelligentes pour les agents de codage et les commandes shell.</sub>
+</p>
+
+<p align="center">
+  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
+  <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+</p>
+
+<p align="center">
+  <sub>Sponsorisé par <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <strong>Français</strong> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.he.md">עברית</a>
+</p>
+
+---
+
+<p align="center">
+  <strong>Frogi, notre mascotte, apparaît lorsque vous exécutez simplement <code>boost</code>.</strong>
+</p>
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+  </picture>
+</p>
+
+**Boost** encapsule les commandes que vos agents exécutent déjà, transformant des journaux bruyants en un contexte compact et structuré qui conserve le signal — erreurs, durées, nombres de changements, accès au cache — tout en réduisant le bruit.
+
+Boost ne sacrifie jamais la qualité pour les économies. Il ne retire que ce qu'il est sûr de supprimer, afin que la sortie de l'agent reste aussi précise. Notre [benchmark Terminal-Bench 2.0](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) le montre : même taux de réussite des tâches, ~12 % de coût en moins — Boost garde les agents optimisés sans jamais freiner leur rythme.
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+  </picture>
+</p>
+
+## Démarrage rapide
+
+**Installer Boost**
+
+macOS / Linux / Windows WSL :
+
+```bash
+curl -fsSL https://boost.jfrog.com/install.sh | bash
+```
+
+Windows PowerShell :
+
+```powershell
+irm https://boost.jfrog.com/install.ps1 | iex
+```
+
+**Connectez-le à Cursor, Claude Code, GitHub Copilot et Codex CLI :**
+
+```bash
+boost init
+```
+
+Pour les agents de codage IA qui installent Boost sur la machine d'un utilisateur, suivez **[AGENT-INSTALL.md](./AGENT-INSTALL.md)**.
+
+## Quand utiliser Boost
+
+- **Longues sessions d'agents de codage** — Gardez le contexte léger sur des dizaines de commandes shell pour que les agents dépensent des tokens sur la tâche, pas sur l'historique de défilement.
+- **Boucles bruyantes de test, de build et de debug** — Compressez `npm test`, `pytest`, `go test`, `docker build`, les linters et les journaux tout en conservant les échecs et les résumés.
+- **Pipelines CI** — Journaux de jobs plus courts et plus faciles à parcourir, avec des signaux de durée et de cache pour GitHub Actions et d'autres runners.
+- **Outils personnalisés ou internes** — Ajoutez des filtres TOML pour vos propres CLI afin que la même boucle de compression couvre les outils que vos agents utilisent réellement.
+
+## Économies de tokens intelligentes
+
+Boost ne se contente pas de tronquer la sortie. Il applique des filtres adaptés à la commande qui préservent ce dont les agents ont besoin pour raisonner sur le résultat.
+
+```bash
+# Without Boost: ~9,800 tokens of install noise
+$ npm ci
+npm warn deprecated inflight@1.0.6 / rimraf@3.0.2 / glob@7.2.3 …
+added 1285 packages, audited 1286 in 45s
+found 0 vulnerabilities
+
+# With Boost: ~640 tokens, same outcome, cache-backed
+$ boost npm ci
+[OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
+```
+
+L'agent voit le résumé utile, pas l'historique de défilement. En cas d'échec, Boost conserve le test en échec, l'erreur du compilateur ou la frame de pile qui compte.
+
+## [En quoi Boost est différent](https://boost.jfrog.com/docs/en/why-boost/)
+
+| Capacité | Boost | RTK | Headroom | Caveman |
+| --- | :---: | :---: | :---: | :---: |
+| Compression de la sortie des commandes | ✓ | ✓ | ✓ | × |
+| Compression du contexte complet et RAG | × | × | ✓ | × |
+| Compression des réponses de l'assistant | × | × | × | ✓ |
+| Récupération de la sortie des commandes | ✓ | ✓ | ✓ | × |
+| L'approbation native voit l'exécutable d'origine | ✓ | × | — | — |
+| Feedback de récupération versionné | ✓ | × | × | × |
+| Désactivation automatique des filtres récupérés de façon répétée | ✓ | × | × | × |
+| A/B de bout en bout tâche d'agent + coût | ✓ | × | × | × |
+
+## Voyez vos économies
+
+Après avoir encapsulé des commandes, ouvrez le rapport web interactif :
+
+```bash
+boost report
+```
+
+Pour un résumé narratif dans le terminal :
+
+```bash
+boost report -t
+# or: boost report --tui
+```
+
+## Ce qu'il encapsule
+
+- **Agents :** Cursor, Claude Code, GitHub Copilot, Codex CLI.
+- **Commandes :** Docker, npm, pytest, Git, GitHub CLI et d'autres commandes shell passent par le même wrapper.
+
+## Comment vos agents utilisent Boost
+
+- `boost docker build ...` — journal de build compressé et résumé du cache de couches
+- `boost npm ci` — résumé des dépendances, cache local de paquets, sortie sûre pour les nouvelles tentatives
+- `boost pytest` — sortie silencieuse sur les exécutions réussies, échecs utiles lorsque les tests cassent
+
+## Mettre à jour
+
+```bash
+boost update
+```
+
+## Documentation
+
+Consultez la [documentation complète](https://boost.jfrog.com/docs/en/overview/) pour les commandes, la configuration et l'export OpenTelemetry.
+
+## Sécurité et confidentialité
+
+- **Local d'abord.** L'historique des commandes et les journaux bruts restent sur votre machine.
+- **Seules les métadonnées sortent.** Lorsque Boost envoie des données d'utilisation, elles vont uniquement à JFrog pour aider à améliorer le produit. Les métadonnées exportées incluent la durée, le code de sortie et les statistiques de cache, jamais les journaux bruts, le contenu des fichiers ou les valeurs d'environnement. Les secrets correspondant à des motifs comme `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` sont expurgés avant l'écriture ou l'export.
+- **Protocole ouvert, binaires signés.** Natif OpenTelemetry. Les binaires sont publiés signés via GitHub Releases.
+
+Politique complète, versions prises en charge et comment signaler une vulnérabilité : voir [SECURITY.md](./SECURITY.md).
+
+## Licence
+
+Copyright © 2026 JFrog Ltd. Tous droits réservés. Voir [LICENSE](LICENSE) et [BETA_AGREEMENT.md](BETA_AGREEMENT.md).
+
+---
+
+*Dédié à la mémoire de Dima Gershovich — un ingénieur brillant, un musicien talentueux et un cher ami.* [Lire l'histoire de Dima](docs/memorial/MEMORIAL.md)

--- a/README.fr.md
+++ b/README.fr.md
@@ -13,22 +13,22 @@
 </p>
 
 <p align="center">
-  <sub>Économies de tokens intelligentes pour les agents de codage et les commandes shell.</sub>
+  <sub>Économies intelligentes de tokens pour les agents de programmation et les commandes shell.</sub>
 </p>
 
 <p align="center">
-  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
-  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
+  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Site web"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Version publiée"></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
-  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
-  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
-  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
-  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Plateformes">
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Téléchargements"></a>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Étoiles GitHub"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Conçu pour les agents">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
 </p>
 
 <p align="center">
-  <sub>Sponsorisé par <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
+  <sub>Soutenu par <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
 </p>
 
 <p align="center">
@@ -44,26 +44,26 @@
 ---
 
 <p align="center">
-  <strong>Frogi, notre mascotte, apparaît lorsque vous exécutez simplement <code>boost</code>.</strong>
+  <strong>Frogi, notre mascotte, apparaît lorsque vous exécutez la commande <code>boost</code> sans argument.</strong>
 </p>
 
 <p align="center">
   <picture>
     <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, la mascotte de Boost" width="180">
   </picture>
 </p>
 
-**Boost** encapsule les commandes que vos agents exécutent déjà, transformant des journaux bruyants en un contexte compact et structuré qui conserve le signal — erreurs, durées, nombres de changements, accès au cache — tout en réduisant le bruit.
+**Boost** encapsule les commandes que vos agents exécutent déjà, transformant des journaux bruyants en un contexte compact et structuré qui conserve le signal — erreurs, durées, nombre de modifications, éléments trouvés dans le cache — tout en réduisant le bruit.
 
-Boost ne sacrifie jamais la qualité pour les économies. Il ne retire que ce qu'il est sûr de supprimer, afin que la sortie de l'agent reste aussi précise. Notre [benchmark Terminal-Bench 2.0](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) le montre : même taux de réussite des tâches, ~12 % de coût en moins — Boost garde les agents optimisés sans jamais freiner leur rythme.
+Boost ne sacrifie jamais la qualité au nom des économies. Il ne supprime que ce qui peut l'être sans risque, afin que la sortie transmise à l'agent reste tout aussi précise. Notre [benchmark Terminal-Bench 2.0](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) le confirme : même taux de réussite des tâches, avec un coût inférieur de ~12 % — Boost maintient les agents à leur niveau optimal sans jamais les ralentir.
 
 <p align="center">
   <picture>
     <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="Utilisation de Boost : installation, boost init, exécution d'une tâche, boost report" width="768">
   </picture>
 </p>
 
@@ -71,7 +71,7 @@ Boost ne sacrifie jamais la qualité pour les économies. Il ne retire que ce qu
 
 **Installer Boost**
 
-macOS / Linux / Windows WSL :
+macOS / Linux / WSL sous Windows :
 
 ```bash
 curl -fsSL https://boost.jfrog.com/install.sh | bash
@@ -83,24 +83,24 @@ Windows PowerShell :
 irm https://boost.jfrog.com/install.ps1 | iex
 ```
 
-**Connectez-le à Cursor, Claude Code, GitHub Copilot et Codex CLI :**
+**Intégrez Boost à Cursor, Claude Code, GitHub Copilot et Codex CLI :**
 
 ```bash
 boost init
 ```
 
-Pour les agents de codage IA qui installent Boost sur la machine d'un utilisateur, suivez **[AGENT-INSTALL.md](./AGENT-INSTALL.md)**.
+Pour les agents IA de programmation qui installent Boost sur la machine d'un utilisateur, suivez les instructions du fichier **[AGENT-INSTALL.md](./AGENT-INSTALL.md)**.
 
 ## Quand utiliser Boost
 
-- **Longues sessions d'agents de codage** — Gardez le contexte léger sur des dizaines de commandes shell pour que les agents dépensent des tokens sur la tâche, pas sur l'historique de défilement.
-- **Boucles bruyantes de test, de build et de debug** — Compressez `npm test`, `pytest`, `go test`, `docker build`, les linters et les journaux tout en conservant les échecs et les résumés.
-- **Pipelines CI** — Journaux de jobs plus courts et plus faciles à parcourir, avec des signaux de durée et de cache pour GitHub Actions et d'autres runners.
-- **Outils personnalisés ou internes** — Ajoutez des filtres TOML pour vos propres CLI afin que la même boucle de compression couvre les outils que vos agents utilisent réellement.
+- **Longues sessions avec des agents de programmation** — Maintenez un contexte léger au fil de dizaines de commandes shell afin que les agents consacrent leurs tokens à la tâche plutôt qu'à l'historique du terminal.
+- **Boucles verbeuses de test, de build et de débogage** — Compressez les sorties de `npm test`, `pytest`, `go test`, `docker build` et des linters, ainsi que les journaux, tout en conservant les détails des échecs et les résumés.
+- **Pipelines CI** — Journaux de tâches plus courts et plus faciles à parcourir, avec des indications sur les durées et l'utilisation du cache pour GitHub Actions et les autres runners.
+- **Outils personnalisés ou internes** — Ajoutez des filtres TOML pour vos propres CLI afin que le même mécanisme de compression s'applique aux outils que vos agents utilisent réellement.
 
-## Économies de tokens intelligentes
+## Économies intelligentes de tokens
 
-Boost ne se contente pas de tronquer la sortie. Il applique des filtres adaptés à la commande qui préservent ce dont les agents ont besoin pour raisonner sur le résultat.
+Boost ne se contente pas de tronquer la sortie. Il applique des filtres qui tiennent compte de la commande et préservent les éléments dont les agents ont besoin pour raisonner à partir du résultat.
 
 ```bash
 # Without Boost: ~9,800 tokens of install noise
@@ -114,46 +114,46 @@ $ boost npm ci
 [OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
 ```
 
-L'agent voit le résumé utile, pas l'historique de défilement. En cas d'échec, Boost conserve le test en échec, l'erreur du compilateur ou la frame de pile qui compte.
+L'agent voit le résumé utile, pas l'historique du terminal. En cas d'échec, Boost conserve les informations qui comptent : le test en échec, l'erreur de compilation ou l'entrée pertinente de la trace de pile.
 
-## [En quoi Boost est différent](https://boost.jfrog.com/docs/en/why-boost/)
+## [Ce qui distingue Boost](https://boost.jfrog.com/docs/en/why-boost/)
 
-| Capacité | Boost | RTK | Headroom | Caveman |
+| Fonctionnalité | Boost | RTK | Headroom | Caveman |
 | --- | :---: | :---: | :---: | :---: |
 | Compression de la sortie des commandes | ✓ | ✓ | ✓ | × |
-| Compression du contexte complet et RAG | × | × | ✓ | × |
+| Compression du contexte complet et du RAG | × | × | ✓ | × |
 | Compression des réponses de l'assistant | × | × | × | ✓ |
 | Récupération de la sortie des commandes | ✓ | ✓ | ✓ | × |
-| L'approbation native voit l'exécutable d'origine | ✓ | × | — | — |
-| Feedback de récupération versionné | ✓ | × | × | × |
-| Désactivation automatique des filtres récupérés de façon répétée | ✓ | × | × | × |
-| A/B de bout en bout tâche d'agent + coût | ✓ | × | × | × |
+| L'interface d'approbation native affiche l'exécutable d'origine | ✓ | × | — | — |
+| Retour d'information versionné sur les récupérations | ✓ | × | × | × |
+| Désactivation automatique des filtres dont la sortie est récupérée à plusieurs reprises | ✓ | × | × | × |
+| Test A/B de bout en bout sur la tâche de l'agent et le coût | ✓ | × | × | × |
 
-## Voyez vos économies
+## Visualisez vos économies
 
-Après avoir encapsulé des commandes, ouvrez le rapport web interactif :
+Une fois les commandes encapsulées, ouvrez le rapport web interactif :
 
 ```bash
 boost report
 ```
 
-Pour un résumé narratif dans le terminal :
+Pour obtenir un résumé en prose dans le terminal :
 
 ```bash
 boost report -t
 # or: boost report --tui
 ```
 
-## Ce qu'il encapsule
+## Ce que Boost encapsule
 
 - **Agents :** Cursor, Claude Code, GitHub Copilot, Codex CLI.
-- **Commandes :** Docker, npm, pytest, Git, GitHub CLI et d'autres commandes shell passent par le même wrapper.
+- **Commandes :** Docker, npm, pytest, Git, GitHub CLI et d'autres commandes shell passent par le même mécanisme d'encapsulation.
 
 ## Comment vos agents utilisent Boost
 
-- `boost docker build ...` — journal de build compressé et résumé du cache de couches
-- `boost npm ci` — résumé des dépendances, cache local de paquets, sortie sûre pour les nouvelles tentatives
-- `boost pytest` — sortie silencieuse sur les exécutions réussies, échecs utiles lorsque les tests cassent
+- `boost docker build ...` — journal de build compressé et résumé de l'utilisation du cache des couches
+- `boost npm ci` — résumé des dépendances, cache local de paquets, sortie fiable en cas de nouvelle tentative
+- `boost pytest` — sortie minimale lorsque les tests réussissent, informations utiles en cas d'échec
 
 ## Mettre à jour
 
@@ -163,15 +163,15 @@ boost update
 
 ## Documentation
 
-Consultez la [documentation complète](https://boost.jfrog.com/docs/en/overview/) pour les commandes, la configuration et l'export OpenTelemetry.
+Consultez la [documentation complète](https://boost.jfrog.com/docs/en/overview/) pour les commandes, la configuration et l'exportation OpenTelemetry.
 
 ## Sécurité et confidentialité
 
-- **Local d'abord.** L'historique des commandes et les journaux bruts restent sur votre machine.
-- **Seules les métadonnées sortent.** Lorsque Boost envoie des données d'utilisation, elles vont uniquement à JFrog pour aider à améliorer le produit. Les métadonnées exportées incluent la durée, le code de sortie et les statistiques de cache, jamais les journaux bruts, le contenu des fichiers ou les valeurs d'environnement. Les secrets correspondant à des motifs comme `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` sont expurgés avant l'écriture ou l'export.
-- **Protocole ouvert, binaires signés.** Natif OpenTelemetry. Les binaires sont publiés signés via GitHub Releases.
+- **Priorité au stockage local.** L'historique des commandes et les journaux bruts restent sur votre machine.
+- **Seules les métadonnées quittent votre machine.** Lorsque Boost envoie des données d'utilisation, elles sont uniquement transmises à JFrog afin d'améliorer le produit. Les métadonnées exportées comprennent la durée d'exécution, le code de sortie et les statistiques de cache, mais jamais les journaux bruts, le contenu des fichiers ni les valeurs des variables d'environnement. Les secrets correspondant à des motifs comme `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` sont expurgés avant leur écriture ou leur exportation.
+- **Protocole ouvert, binaires signés.** Intégration native d'OpenTelemetry. Les binaires signés sont distribués via GitHub Releases.
 
-Politique complète, versions prises en charge et comment signaler une vulnérabilité : voir [SECURITY.md](./SECURITY.md).
+Pour consulter la politique complète, connaître les versions prises en charge et savoir comment signaler une vulnérabilité, voir [SECURITY.md](./SECURITY.md).
 
 ## Licence
 

--- a/README.he.md
+++ b/README.he.md
@@ -8,26 +8,26 @@
   </a>
 </p>
 
-<p align="center">
-  <strong>חסכו בטוקנים. ממקסמו את ההקשר.</strong>
+<p align="center" dir="rtl">
+  <strong>חסכו בטוקנים. הפיקו את המרב מההקשר.</strong>
 </p>
 
-<p align="center">
+<p align="center" dir="rtl">
   <sub>חיסכון חכם בטוקנים לסוכני קוד ולפקודות shell.</sub>
 </p>
 
 <p align="center">
-  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
-  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
+  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="אתר"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="גרסה"></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
-  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
-  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
-  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
-  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="פלטפורמות">
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="הורדות"></a>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="כוכבים ב-GitHub"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="מותאם לסוכנים">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
 </p>
 
-<p align="center">
+<p align="center" dir="rtl">
   <sub>בחסות <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
 </p>
 
@@ -43,27 +43,27 @@
 
 ---
 
-<p align="center">
-  <strong>Frogi, הקמע שלנו, מופיע כשמריצים רק <code>boost</code>.</strong>
+<p align="center" dir="rtl">
+  <strong>הקמע שלנו, Frogi, מופיע כשמריצים את <code>boost</code> ללא ארגומנטים.</strong>
 </p>
 
 <p align="center">
   <picture>
     <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, הקמע של Boost" width="180">
   </picture>
 </p>
 
-**Boost** עוטף את הפקודות שסוכניכם כבר מריצים, והופך לוגים רועשים להקשר קומפקטי ומבני ששומר על האות — שגיאות, זמנים, מספרי שינויים, פגיעות מטמון — תוך צמצום הרעש.
+הכלי **Boost** עוטף את הפקודות שהסוכנים שלכם כבר מריצים והופך לוגים רועשים להקשר קומפקטי ומובנה, תוך שמירה על המידע החשוב — שגיאות, נתוני תזמון, מספר הפריטים שהשתנו ופגיעות במטמון — וצמצום הרעש.
 
-Boost לעולם אינו מוותר על איכות למען חיסכון. הוא גוזם רק את מה שבטוח להסיר, כך שפלט הסוכן נשאר חד כמו קודם. ה[בנצ'מרק Terminal-Bench 2.0](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) שלנו מראה זאת: שיעור הצלחה זהה במשימות, עלות נמוכה בכ־12% — Boost שומר על הסוכנים ממוטבים מבלי לשבור את הקצב.
+עם Boost לעולם לא מקריבים איכות לטובת חיסכון. הכלי מסיר רק את מה שניתן להשמיט בבטחה, כך שפלט הסוכן נשאר איכותי באותה המידה. [הבנצ'מרק Terminal-Bench 2.0 שלנו](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) ממחיש זאת: שיעור הצלחה זהה במשימות ועלות נמוכה בכ־12% — Boost שומר על יעילות הסוכנים בלי לפגוע ברצף עבודתם.
 
 <p align="center">
   <picture>
     <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="כיצד להשתמש ב-Boost: התקנה, boost init, הרצת משימה, boost report" width="768">
   </picture>
 </p>
 
@@ -83,24 +83,24 @@ Windows PowerShell:
 irm https://boost.jfrog.com/install.ps1 | iex
 ```
 
-**חברו אותו ל-Cursor, Claude Code, GitHub Copilot ו-Codex CLI:**
+**שלבו את Boost עם Cursor, Claude Code, GitHub Copilot ו-Codex CLI:**
 
 ```bash
 boost init
 ```
 
-עבור סוכני קוד מבוססי AI שמתקינים את Boost במחשב של משתמש, עקבו אחר **[AGENT-INSTALL.md](./AGENT-INSTALL.md)**.
+סוכני קוד מבוססי AI שמתקינים את Boost במחשב של משתמש צריכים לפעול לפי **[AGENT-INSTALL.md](./AGENT-INSTALL.md)**.
 
 ## מתי להשתמש ב-Boost
 
-- **סשנים ארוכים של סוכני קוד** — שמרו על הקשר רזה לאורך עשרות פקודות shell כדי שהסוכנים יוציאו טוקנים על המשימה, לא על היסטוריית הגלילה.
-- **לולאות רועשות של בדיקות, בנייה ודיבוג** — דחסו `npm test`, `pytest`, `go test`, `docker build`, linters ולוגים תוך שמירה על כשלים וסיכומים.
-- **צינורות CI** — לוגי משימות קצרים וקלים יותר לסריקה, עם אותות תזמון ומטמון עבור GitHub Actions ו-runners אחרים.
-- **כלים מותאמים או פנימיים** — הוסיפו מסנני TOML ל-CLI שלכם כך שאותה לולאת דחיסה תכסה את הכלים שסוכניכם באמת מריצים.
+- **סשנים ארוכים של סוכני קוד** — שמרו על הקשר תמציתי לאורך עשרות פקודות shell כדי שהסוכנים ישתמשו בטוקנים למשימה ולא לעיבוד הפלט הקודם במסוף.
+- **מחזורי בדיקה, בנייה ודיבוג עתירי פלט** — דחסו `npm test`, `pytest`, `go test`, `docker build`, כלי lint ולוגים, תוך שמירה על פרטי הכשלים ועל הסיכומים.
+- **תהליכי CI** — לוגי הרצה קצרים יותר, שקל יותר לסרוק, עם נתוני תזמון ומטמון עבור GitHub Actions ומערכות הרצה אחרות.
+- **כלים מותאמים אישית או פנימיים** — הוסיפו מסנני TOML לכלי שורת הפקודה שלכם, כך שאותו מנגנון דחיסה יחול גם על הכלים שהסוכנים שלכם מריצים בפועל.
 
 ## חיסכון חכם בטוקנים
 
-Boost אינו רק מקצץ את הפלט. הוא מחיל מסננים מודעי-פקודה ששומרים על מה שהסוכנים צריכים כדי להסיק מסקנות לגבי התוצאה.
+הסינון של Boost אינו מסתכם בקטיעת הפלט. Boost מחיל מסננים המותאמים לפקודה ומשמרים את המידע שהסוכנים זקוקים לו כדי לנתח את התוצאה.
 
 ```bash
 # Without Boost: ~9,800 tokens of install noise
@@ -114,46 +114,46 @@ $ boost npm ci
 [OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
 ```
 
-הסוכן רואה את הסיכום השימושי, לא את היסטוריית הגלילה. בכשלים, Boost שומר את הבדיקה שנכשלה, את שגיאת המהדר או את מסגרת ה-stack שחשובה.
+הסוכן רואה את הסיכום השימושי במקום את כל הפלט הקודם. במקרה של כשל, Boost משאיר את הבדיקה שנכשלה, את שגיאת המהדר או את מסגרת המחסנית הרלוונטית.
 
 ## [במה Boost שונה](https://boost.jfrog.com/docs/en/why-boost/)
 
 | יכולת | Boost | RTK | Headroom | Caveman |
 | --- | :---: | :---: | :---: | :---: |
 | דחיסת פלט פקודות | ✓ | ✓ | ✓ | × |
-| דחיסת הקשר מלא ו-RAG | × | × | ✓ | × |
+| דחיסת הקשר מלא ודחיסת RAG | × | × | ✓ | × |
 | דחיסת תשובות העוזר | × | × | × | ✓ |
 | שחזור פלט פקודות | ✓ | ✓ | ✓ | × |
-| אישור מקורי רואה את הקובץ המקורי להרצה | ✓ | × | — | — |
-| משוב שחזור מגרסאות | ✓ | × | × | × |
-| השבתה אוטומטית של מסננים שנשלפו שוב ושוב | ✓ | × | × | × |
-| A/B מקצה לקצה של משימת סוכן + עלות | ✓ | × | × | × |
+| מנגנון האישור המובנה רואה את קובץ ההפעלה המקורי | ✓ | × | — | — |
+| משוב אחזור לפי גרסה | ✓ | × | × | × |
+| השבתה אוטומטית של מסננים שהפלט שלהם מאוחזר שוב ושוב | ✓ | × | × | × |
+| בדיקת A/B מקצה לקצה של משימת סוכן ועלותה | ✓ | × | × | × |
 
 ## ראו את החיסכון שלכם
 
-לאחר עטיפת פקודות, פתחו את דוח האינטרנט האינטראקטיבי:
+לאחר הרצת פקודות דרך Boost, פתחו את הדוח האינטראקטיבי בדפדפן:
 
 ```bash
 boost report
 ```
 
-לסיכום נרטיבי בטרמינל:
+לקבלת סיכום מילולי במסוף:
 
 ```bash
 boost report -t
 # or: boost report --tui
 ```
 
-## מה הוא עוטף
+## מה Boost עוטף
 
 - **סוכנים:** Cursor, Claude Code, GitHub Copilot, Codex CLI.
-- **פקודות:** Docker, npm, pytest, Git, GitHub CLI ופקודות shell אחרות עוברות באותו wrapper.
+- **פקודות:** אותה מעטפת משמשת לפקודות של Docker, npm, pytest, Git ו-GitHub CLI ולפקודות shell אחרות.
 
 ## איך הסוכנים שלכם משתמשים ב-Boost
 
-- `boost docker build ...` — לוג בנייה דחוס וסיכום מטמון שכבות
-- `boost npm ci` — סיכום תלויות, מטמון חבילות מקומי, פלט בטוח לניסיונות חוזרים
-- `boost pytest` — פלט שקט בהרצות ירוקות, כשלים שימושיים כשבדיקות נשברות
+- `boost docker build ...` — לוג בנייה דחוס וסיכום השימוש במטמון השכבות
+- `boost npm ci` — סיכום תלויות, מטמון חבילות מקומי, פלט בטוח גם בניסיונות חוזרים
+- `boost pytest` — פלט מצומצם בהרצות מוצלחות ופרטי כשל שימושיים כשהבדיקות נכשלות
 
 ## עדכון
 
@@ -163,19 +163,19 @@ boost update
 
 ## תיעוד
 
-ראו את ה[תיעוד המלא](https://boost.jfrog.com/docs/en/overview/) לפקודות, תצורה וייצוא OpenTelemetry.
+[התיעוד המלא](https://boost.jfrog.com/docs/en/overview/) כולל מידע על פקודות, תצורה וייצוא נתונים באמצעות OpenTelemetry.
 
 ## אבטחה ופרטיות
 
-- **מקומי תחילה.** היסטוריית הפקודות והלוגים הגולמיים נשארים במחשב שלכם.
-- **רק מטא-נתונים יוצאים.** כש-Boost שולח נתוני שימוש, הם מגיעים רק ל-JFrog כדי לסייע בשיפור המוצר. מטא-נתונים מיוצאים כוללים תזמון, קוד יציאה וסטטיסטיקות מטמון — לעולם לא לוגים גולמיים, תוכן קבצים או ערכי סביבה. סודות התואמים לתבניות כמו `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` מוסתרים לפני כתיבה או ייצוא.
-- **פרוטוקול פתוח, בינאריים חתומים.** מותאם ל-OpenTelemetry. הבינאריים מגיעים חתומים דרך GitHub Releases.
+- **מקומי כברירת מחדל.** היסטוריית הפקודות והלוגים הגולמיים נשארים במחשב שלכם.
+- **רק מטא-נתונים יוצאים מהמחשב.** כאשר Boost שולח נתוני שימוש, הם נשלחים אך ורק ל-JFrog לצורך שיפור המוצר. המטא-נתונים המיוצאים כוללים נתוני תזמון, קוד יציאה וסטטיסטיקות מטמון — ולעולם לא לוגים גולמיים, תוכן קבצים או ערכים של משתני סביבה. ערכים סודיים התואמים לתבניות כמו `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` מושחרים לפני כתיבה או ייצוא.
+- **פרוטוקול פתוח וקבצים בינאריים חתומים.** תמיכה מובנית ב־OpenTelemetry. הקבצים הבינאריים החתומים מופצים דרך GitHub Releases.
 
-מדיניות מלאה, גרסאות נתמכות וכיצד לדווח על פגיעוּת: ראו [SECURITY.md](./SECURITY.md).
+לפרטים על המדיניות המלאה, הגרסאות הנתמכות ואופן הדיווח על חולשת אבטחה, ראו [SECURITY.md](./SECURITY.md).
 
 ## רישיון
 
-Copyright © 2026 JFrog Ltd. כל הזכויות שמורות. ראו [LICENSE](LICENSE) ו-[BETA_AGREEMENT.md](BETA_AGREEMENT.md).
+זכויות יוצרים © 2026 JFrog Ltd. כל הזכויות שמורות. ראו [LICENSE](LICENSE) ו-[BETA_AGREEMENT.md](BETA_AGREEMENT.md).
 
 ---
 

--- a/README.he.md
+++ b/README.he.md
@@ -1,0 +1,182 @@
+<p align="center">
+  <a href="https://boost.jfrog.com/">
+    <picture>
+      <source srcset=".github/assets/boost-logo-dark.png" media="(prefers-color-scheme: dark)">
+      <source srcset=".github/assets/boost-logo-light.png" media="(prefers-color-scheme: light)">
+      <img src=".github/assets/boost-logo-light.png" alt="Boost" width="260">
+    </picture>
+  </a>
+</p>
+
+<p align="center">
+  <strong>חסכו בטוקנים. ממקסמו את ההקשר.</strong>
+</p>
+
+<p align="center">
+  <sub>חיסכון חכם בטוקנים לסוכני קוד ולפקודות shell.</sub>
+</p>
+
+<p align="center">
+  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
+  <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+</p>
+
+<p align="center">
+  <sub>בחסות <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <strong>עברית</strong>
+</p>
+
+---
+
+<p align="center">
+  <strong>Frogi, הקמע שלנו, מופיע כשמריצים רק <code>boost</code>.</strong>
+</p>
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+  </picture>
+</p>
+
+**Boost** עוטף את הפקודות שסוכניכם כבר מריצים, והופך לוגים רועשים להקשר קומפקטי ומבני ששומר על האות — שגיאות, זמנים, מספרי שינויים, פגיעות מטמון — תוך צמצום הרעש.
+
+Boost לעולם אינו מוותר על איכות למען חיסכון. הוא גוזם רק את מה שבטוח להסיר, כך שפלט הסוכן נשאר חד כמו קודם. ה[בנצ'מרק Terminal-Bench 2.0](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) שלנו מראה זאת: שיעור הצלחה זהה במשימות, עלות נמוכה בכ־12% — Boost שומר על הסוכנים ממוטבים מבלי לשבור את הקצב.
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+  </picture>
+</p>
+
+## התחלה מהירה
+
+**התקנת Boost**
+
+macOS / Linux / Windows WSL:
+
+```bash
+curl -fsSL https://boost.jfrog.com/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://boost.jfrog.com/install.ps1 | iex
+```
+
+**חברו אותו ל-Cursor, Claude Code, GitHub Copilot ו-Codex CLI:**
+
+```bash
+boost init
+```
+
+עבור סוכני קוד מבוססי AI שמתקינים את Boost במחשב של משתמש, עקבו אחר **[AGENT-INSTALL.md](./AGENT-INSTALL.md)**.
+
+## מתי להשתמש ב-Boost
+
+- **סשנים ארוכים של סוכני קוד** — שמרו על הקשר רזה לאורך עשרות פקודות shell כדי שהסוכנים יוציאו טוקנים על המשימה, לא על היסטוריית הגלילה.
+- **לולאות רועשות של בדיקות, בנייה ודיבוג** — דחסו `npm test`, `pytest`, `go test`, `docker build`, linters ולוגים תוך שמירה על כשלים וסיכומים.
+- **צינורות CI** — לוגי משימות קצרים וקלים יותר לסריקה, עם אותות תזמון ומטמון עבור GitHub Actions ו-runners אחרים.
+- **כלים מותאמים או פנימיים** — הוסיפו מסנני TOML ל-CLI שלכם כך שאותה לולאת דחיסה תכסה את הכלים שסוכניכם באמת מריצים.
+
+## חיסכון חכם בטוקנים
+
+Boost אינו רק מקצץ את הפלט. הוא מחיל מסננים מודעי-פקודה ששומרים על מה שהסוכנים צריכים כדי להסיק מסקנות לגבי התוצאה.
+
+```bash
+# Without Boost: ~9,800 tokens of install noise
+$ npm ci
+npm warn deprecated inflight@1.0.6 / rimraf@3.0.2 / glob@7.2.3 …
+added 1285 packages, audited 1286 in 45s
+found 0 vulnerabilities
+
+# With Boost: ~640 tokens, same outcome, cache-backed
+$ boost npm ci
+[OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
+```
+
+הסוכן רואה את הסיכום השימושי, לא את היסטוריית הגלילה. בכשלים, Boost שומר את הבדיקה שנכשלה, את שגיאת המהדר או את מסגרת ה-stack שחשובה.
+
+## [במה Boost שונה](https://boost.jfrog.com/docs/en/why-boost/)
+
+| יכולת | Boost | RTK | Headroom | Caveman |
+| --- | :---: | :---: | :---: | :---: |
+| דחיסת פלט פקודות | ✓ | ✓ | ✓ | × |
+| דחיסת הקשר מלא ו-RAG | × | × | ✓ | × |
+| דחיסת תשובות העוזר | × | × | × | ✓ |
+| שחזור פלט פקודות | ✓ | ✓ | ✓ | × |
+| אישור מקורי רואה את הקובץ המקורי להרצה | ✓ | × | — | — |
+| משוב שחזור מגרסאות | ✓ | × | × | × |
+| השבתה אוטומטית של מסננים שנשלפו שוב ושוב | ✓ | × | × | × |
+| A/B מקצה לקצה של משימת סוכן + עלות | ✓ | × | × | × |
+
+## ראו את החיסכון שלכם
+
+לאחר עטיפת פקודות, פתחו את דוח האינטרנט האינטראקטיבי:
+
+```bash
+boost report
+```
+
+לסיכום נרטיבי בטרמינל:
+
+```bash
+boost report -t
+# or: boost report --tui
+```
+
+## מה הוא עוטף
+
+- **סוכנים:** Cursor, Claude Code, GitHub Copilot, Codex CLI.
+- **פקודות:** Docker, npm, pytest, Git, GitHub CLI ופקודות shell אחרות עוברות באותו wrapper.
+
+## איך הסוכנים שלכם משתמשים ב-Boost
+
+- `boost docker build ...` — לוג בנייה דחוס וסיכום מטמון שכבות
+- `boost npm ci` — סיכום תלויות, מטמון חבילות מקומי, פלט בטוח לניסיונות חוזרים
+- `boost pytest` — פלט שקט בהרצות ירוקות, כשלים שימושיים כשבדיקות נשברות
+
+## עדכון
+
+```bash
+boost update
+```
+
+## תיעוד
+
+ראו את ה[תיעוד המלא](https://boost.jfrog.com/docs/en/overview/) לפקודות, תצורה וייצוא OpenTelemetry.
+
+## אבטחה ופרטיות
+
+- **מקומי תחילה.** היסטוריית הפקודות והלוגים הגולמיים נשארים במחשב שלכם.
+- **רק מטא-נתונים יוצאים.** כש-Boost שולח נתוני שימוש, הם מגיעים רק ל-JFrog כדי לסייע בשיפור המוצר. מטא-נתונים מיוצאים כוללים תזמון, קוד יציאה וסטטיסטיקות מטמון — לעולם לא לוגים גולמיים, תוכן קבצים או ערכי סביבה. סודות התואמים לתבניות כמו `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` מוסתרים לפני כתיבה או ייצוא.
+- **פרוטוקול פתוח, בינאריים חתומים.** מותאם ל-OpenTelemetry. הבינאריים מגיעים חתומים דרך GitHub Releases.
+
+מדיניות מלאה, גרסאות נתמכות וכיצד לדווח על פגיעוּת: ראו [SECURITY.md](./SECURITY.md).
+
+## רישיון
+
+Copyright © 2026 JFrog Ltd. כל הזכויות שמורות. ראו [LICENSE](LICENSE) ו-[BETA_AGREEMENT.md](BETA_AGREEMENT.md).
+
+---
+
+*מוקדש לזכרו של דימה גרשוביץ' — מהנדס מבריק, מוזיקאי מוכשר וחבר יקר.* [קראו את סיפורו של דימה](docs/memorial/MEMORIAL.md)

--- a/README.he.md
+++ b/README.he.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center" dir="rtl">
-  <strong>חסכו בטוקנים. הפיקו את המרב מההקשר.</strong>
+  <strong>חסכו בטוקנים. שפרו את דיוק הסוכנים.</strong>
 </p>
 
 <p align="center" dir="rtl">

--- a/README.hi.md
+++ b/README.hi.md
@@ -1,0 +1,182 @@
+<p align="center">
+  <a href="https://boost.jfrog.com/">
+    <picture>
+      <source srcset=".github/assets/boost-logo-dark.png" media="(prefers-color-scheme: dark)">
+      <source srcset=".github/assets/boost-logo-light.png" media="(prefers-color-scheme: light)">
+      <img src=".github/assets/boost-logo-light.png" alt="Boost" width="260">
+    </picture>
+  </a>
+</p>
+
+<p align="center">
+  <strong>टोकन बचाएँ। कॉन्टेक्स्ट को अधिकतम करें।</strong>
+</p>
+
+<p align="center">
+  <sub>कोडिंग एजेंट्स और शेल कमांड के लिए स्मार्ट टोकन बचत।</sub>
+</p>
+
+<p align="center">
+  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
+  <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+</p>
+
+<p align="center">
+  <sub>प्रायोजक: <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <strong>हिन्दी</strong> ·
+  <a href="README.he.md">עברית</a>
+</p>
+
+---
+
+<p align="center">
+  <strong>हमारा शुभंकर Frogi तब प्रकट होता है जब आप केवल <code>boost</code> चलाते हैं।</strong>
+</p>
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+  </picture>
+</p>
+
+**Boost** उन कमांड को रैप करता है जिन्हें आपके एजेंट पहले से चलाते हैं, शोरगुल भरे लॉग को कॉम्पैक्ट, संरचित कॉन्टेक्स्ट में बदलता है जो सिग्नल — त्रुटियाँ, समय, परिवर्तन गणना, कैश हिट — रखता है और शोर कम करता है।
+
+Boost कभी बचत के लिए गुणवत्ता का सौदा नहीं करता। यह केवल वही काटता है जिसे सुरक्षित रूप से हटाया जा सकता है, ताकि एजेंट आउटपुट उतना ही तेज़ बना रहे। हमारा [Terminal-Bench 2.0 बेंचमार्क](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) यही दिखाता है: समान टास्क पास दर, ~12% कम लागत — Boost एजेंट्स को बिना उनकी गति तोड़े अनुकूलित रखता है।
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+  </picture>
+</p>
+
+## त्वरित शुरुआत
+
+**Boost इंस्टॉल करें**
+
+macOS / Linux / Windows WSL:
+
+```bash
+curl -fsSL https://boost.jfrog.com/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://boost.jfrog.com/install.ps1 | iex
+```
+
+**इसे Cursor, Claude Code, GitHub Copilot और Codex CLI से जोड़ें:**
+
+```bash
+boost init
+```
+
+उपयोगकर्ता की मशीन पर Boost इंस्टॉल करने वाले AI कोडिंग एजेंट्स के लिए **[AGENT-INSTALL.md](./AGENT-INSTALL.md)** का पालन करें।
+
+## Boost कब उपयोग करें
+
+- **लंबे कोडिंग-एजेंट सत्र** — दर्जनों शेल कमांड में कॉन्टेक्स्ट को दुबला रखें ताकि एजेंट स्क्रॉलबैक पर नहीं, टास्क पर टोकन खर्च करें।
+- **शोरगुल भरे टेस्ट, बिल्ड और डिबग लूप** — `npm test`, `pytest`, `go test`, `docker build`, लिंटर्स और लॉग को संपीड़ित करें, विफलताओं और सारांशों को बनाए रखते हुए।
+- **CI पाइपलाइन** — GitHub Actions और अन्य रनर्स के लिए समय और कैश सिग्नल के साथ छोटे, स्कैन करने में आसान जॉब लॉग।
+- **कस्टम या आंतरिक टूल** — अपने CLI के लिए TOML फ़िल्टर जोड़ें ताकि वही संपीड़न लूप उन टूल्स को कवर करे जिन्हें आपके एजेंट वास्तव में चलाते हैं।
+
+## स्मार्ट टोकन बचत
+
+Boost केवल आउटपुट को काटता नहीं है। यह कमांड-जागरूक फ़िल्टर लागू करता है जो वह सुरक्षित रखते हैं जिसकी एजेंट्स को परिणाम पर तर्क करने के लिए आवश्यकता होती है।
+
+```bash
+# Without Boost: ~9,800 tokens of install noise
+$ npm ci
+npm warn deprecated inflight@1.0.6 / rimraf@3.0.2 / glob@7.2.3 …
+added 1285 packages, audited 1286 in 45s
+found 0 vulnerabilities
+
+# With Boost: ~640 tokens, same outcome, cache-backed
+$ boost npm ci
+[OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
+```
+
+एजेंट स्क्रॉलबैक नहीं, उपयोगी सारांश देखता है। विफलताओं पर, Boost वह विफल टेस्ट, कंपाइलर त्रुटि, या स्टैक फ्रेम रखता है जो मायने रखता है।
+
+## [Boost कैसे अलग है](https://boost.jfrog.com/docs/en/why-boost/)
+
+| क्षमता | Boost | RTK | Headroom | Caveman |
+| --- | :---: | :---: | :---: | :---: |
+| कमांड आउटपुट संपीड़न | ✓ | ✓ | ✓ | × |
+| पूर्ण-कॉन्टेक्स्ट और RAG संपीड़न | × | × | ✓ | × |
+| सहायक उत्तर संपीड़न | × | × | × | ✓ |
+| कमांड आउटपुट पुनर्प्राप्ति | ✓ | ✓ | ✓ | × |
+| नेटिव अनुमोदन मूल एक्ज़ीक्यूटेबल देखता है | ✓ | × | — | — |
+| वर्शन्ड पुनर्प्राप्ति फ़ीडबैक | ✓ | × | × | × |
+| बार-बार पुनर्प्राप्त फ़िल्टर स्वतः अक्षम करें | ✓ | × | × | × |
+| एंड-टू-एंड एजेंट टास्क + लागत A/B | ✓ | × | × | × |
+
+## अपनी बचत देखें
+
+कमांड रैप करने के बाद, इंटरैक्टिव वेब रिपोर्ट खोलें:
+
+```bash
+boost report
+```
+
+टर्मिनल नैरेटिव सारांश के लिए:
+
+```bash
+boost report -t
+# or: boost report --tui
+```
+
+## यह क्या रैप करता है
+
+- **एजेंट्स:** Cursor, Claude Code, GitHub Copilot, Codex CLI।
+- **कमांड:** Docker, npm, pytest, Git, GitHub CLI, और अन्य शेल कमांड उसी रैपर से गुज़रते हैं।
+
+## आपके एजेंट Boost कैसे उपयोग करते हैं
+
+- `boost docker build ...` — संपीड़ित बिल्ड लॉग और लेयर-कैश सारांश
+- `boost npm ci` — निर्भरता सारांश, स्थानीय पैकेज कैश, पुनः प्रयास-सुरक्षित आउटपुट
+- `boost pytest` — हरी रन पर शांत आउटपुट, टेस्ट टूटने पर उपयोगी विफलताएँ
+
+## अपडेट
+
+```bash
+boost update
+```
+
+## दस्तावेज़ीकरण
+
+कमांड, कॉन्फ़िगरेशन और OpenTelemetry एक्सपोर्ट के लिए [पूर्ण दस्तावेज़ीकरण](https://boost.jfrog.com/docs/en/overview/) देखें।
+
+## सुरक्षा और गोपनीयता
+
+- **लोकल-फर्स्ट।** कमांड इतिहास और कच्चे लॉग आपकी मशीन पर रहते हैं।
+- **केवल मेटाडेटा बाहर जाता है।** जब Boost उपयोग डेटा भेजता है, तो वह उत्पाद सुधारने में मदद के लिए केवल JFrog को जाता है। निर्यात किए गए मेटाडेटा में समय, एग्ज़िट कोड और कैश आँकड़े शामिल हैं — कभी कच्चे लॉग, फ़ाइल सामग्री या एन्व मान नहीं। `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` जैसे पैटर्न से मेल खाने वाले सीक्रेट्स लेखन या निर्यात से पहले रिडैक्ट कर दिए जाते हैं।
+- **ओपन प्रोटोकॉल, हस्ताक्षरित बाइनरी।** OpenTelemetry-नेटिव। बाइनरी GitHub Releases के माध्यम से हस्ताक्षरित होकर आती हैं।
+
+पूर्ण नीति, समर्थित संस्करण, और भेद्यता की रिपोर्ट कैसे करें: [SECURITY.md](./SECURITY.md) देखें।
+
+## लाइसेंस
+
+Copyright © 2026 JFrog Ltd. सर्वाधिकार सुरक्षित। [LICENSE](LICENSE) और [BETA_AGREEMENT.md](BETA_AGREEMENT.md) देखें।
+
+---
+
+*Dima Gershovich की स्मृति को समर्पित — एक प्रतिभाशाली इंजीनियर, एक प्रतिभाशाली संगीतकार, और एक प्रिय मित्र।* [Dima की कहानी पढ़ें](docs/memorial/MEMORIAL.md)

--- a/README.hi.md
+++ b/README.hi.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <strong>टोकन बचाएँ। कॉन्टेक्स्ट को अधिकतम करें।</strong>
+  <strong>टोकन बचाएँ। कॉन्टेक्स्ट का अधिकतम उपयोग करें।</strong>
 </p>
 
 <p align="center">
@@ -17,18 +17,18 @@
 </p>
 
 <p align="center">
-  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
-  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
+  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="वेबसाइट"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="रिलीज़"></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
-  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
-  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
-  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
-  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="प्लैटफ़ॉर्म्स">
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="डाउनलोड्स"></a>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="स्टार्स"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="एजेंट-नेटिव">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
 </p>
 
 <p align="center">
-  <sub>प्रायोजक: <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
+  <sub><a href="https://jfrog.com"><strong>JFrog</strong></a> द्वारा प्रायोजित</sub>
 </p>
 
 <p align="center">
@@ -44,30 +44,30 @@
 ---
 
 <p align="center">
-  <strong>हमारा शुभंकर Frogi तब प्रकट होता है जब आप केवल <code>boost</code> चलाते हैं।</strong>
+  <strong>सिर्फ़ <code>boost</code> चलाने पर हमारा मैस्कॉट Frogi दिखाई देता है।</strong>
 </p>
 
 <p align="center">
   <picture>
     <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, Boost का मैस्कॉट" width="180">
   </picture>
 </p>
 
-**Boost** उन कमांड को रैप करता है जिन्हें आपके एजेंट पहले से चलाते हैं, शोरगुल भरे लॉग को कॉम्पैक्ट, संरचित कॉन्टेक्स्ट में बदलता है जो सिग्नल — त्रुटियाँ, समय, परिवर्तन गणना, कैश हिट — रखता है और शोर कम करता है।
+**Boost** उन कमांड्स को रैप करता है जिन्हें आपके एजेंट पहले से चलाते हैं। यह शोरगुल वाले लॉग्स को कॉम्पैक्ट, स्ट्रक्चर्ड कॉन्टेक्स्ट में बदलता है, जिसमें ज़रूरी सिग्नल — एरर्स, टाइमिंग, बदलावों की संख्या और कैश हिट्स — बने रहते हैं, जबकि अनावश्यक जानकारी हट जाती है।
 
-Boost कभी बचत के लिए गुणवत्ता का सौदा नहीं करता। यह केवल वही काटता है जिसे सुरक्षित रूप से हटाया जा सकता है, ताकि एजेंट आउटपुट उतना ही तेज़ बना रहे। हमारा [Terminal-Bench 2.0 बेंचमार्क](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) यही दिखाता है: समान टास्क पास दर, ~12% कम लागत — Boost एजेंट्स को बिना उनकी गति तोड़े अनुकूलित रखता है।
+Boost टोकन बचाने के लिए कभी क्वालिटी से समझौता नहीं करता। यह सिर्फ़ वही हटाता है जिसे सुरक्षित रूप से हटाया जा सकता है, इसलिए एजेंट्स का आउटपुट उतना ही सटीक और उपयोगी रहता है। हमारा [Terminal-Bench 2.0 बेंचमार्क](https://boost.jfrog.com/blog/benchmarks-terminal-bench/) यही दिखाता है: एक जैसी टास्क पास रेट और ~12% कम लागत — Boost एजेंट्स के काम में रुकावट डाले बिना उन्हें ऑप्टिमाइज़ रखता है।
 
 <p align="center">
   <picture>
     <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost इस्तेमाल करने का तरीका: इंस्टॉल करें, boost init चलाएँ, टास्क चलाएँ, boost report देखें" width="768">
   </picture>
 </p>
 
-## त्वरित शुरुआत
+## क्विक स्टार्ट
 
 **Boost इंस्टॉल करें**
 
@@ -83,24 +83,24 @@ Windows PowerShell:
 irm https://boost.jfrog.com/install.ps1 | iex
 ```
 
-**इसे Cursor, Claude Code, GitHub Copilot और Codex CLI से जोड़ें:**
+**इसे Cursor, Claude Code, GitHub Copilot और Codex CLI के साथ सेट अप करें:**
 
 ```bash
 boost init
 ```
 
-उपयोगकर्ता की मशीन पर Boost इंस्टॉल करने वाले AI कोडिंग एजेंट्स के लिए **[AGENT-INSTALL.md](./AGENT-INSTALL.md)** का पालन करें।
+अगर कोई AI कोडिंग एजेंट यूज़र की मशीन पर Boost इंस्टॉल कर रहा है, तो **[AGENT-INSTALL.md](./AGENT-INSTALL.md)** का पालन करें।
 
-## Boost कब उपयोग करें
+## Boost का इस्तेमाल कब करें
 
-- **लंबे कोडिंग-एजेंट सत्र** — दर्जनों शेल कमांड में कॉन्टेक्स्ट को दुबला रखें ताकि एजेंट स्क्रॉलबैक पर नहीं, टास्क पर टोकन खर्च करें।
-- **शोरगुल भरे टेस्ट, बिल्ड और डिबग लूप** — `npm test`, `pytest`, `go test`, `docker build`, लिंटर्स और लॉग को संपीड़ित करें, विफलताओं और सारांशों को बनाए रखते हुए।
-- **CI पाइपलाइन** — GitHub Actions और अन्य रनर्स के लिए समय और कैश सिग्नल के साथ छोटे, स्कैन करने में आसान जॉब लॉग।
-- **कस्टम या आंतरिक टूल** — अपने CLI के लिए TOML फ़िल्टर जोड़ें ताकि वही संपीड़न लूप उन टूल्स को कवर करे जिन्हें आपके एजेंट वास्तव में चलाते हैं।
+- **लंबे कोडिंग-एजेंट सेशन्स** — दर्जनों शेल कमांड्स के दौरान कॉन्टेक्स्ट को हल्का रखें, ताकि एजेंट्स स्क्रॉलबैक पर नहीं बल्कि टास्क पर टोकन्स खर्च करें।
+- **शोरगुल वाले टेस्ट, बिल्ड और डिबग लूप्स** — विफलताओं और सारांशों को बनाए रखते हुए `npm test`, `pytest`, `go test`, `docker build`, लिंटर्स और लॉग्स के आउटपुट को कम्प्रेस करें।
+- **CI पाइपलाइन्स** — GitHub Actions और दूसरे रनर्स के लिए छोटे, आसानी से स्कैन किए जा सकने वाले जॉब लॉग्स, जिनमें टाइमिंग और कैश की ज़रूरी जानकारी बनी रहती है।
+- **कस्टम या इन-हाउस टूल्स** — अपने CLIs के लिए TOML फ़िल्टर्स जोड़ें, ताकि यही कम्प्रेशन प्रक्रिया उन टूल्स पर भी लागू हो जिन्हें आपके एजेंट वास्तव में चलाते हैं।
 
 ## स्मार्ट टोकन बचत
 
-Boost केवल आउटपुट को काटता नहीं है। यह कमांड-जागरूक फ़िल्टर लागू करता है जो वह सुरक्षित रखते हैं जिसकी एजेंट्स को परिणाम पर तर्क करने के लिए आवश्यकता होती है।
+Boost आउटपुट को सिर्फ़ ट्रंकेट नहीं करता। यह कमांड के हिसाब से फ़िल्टर्स लागू करता है, जो नतीजे का विश्लेषण करने के लिए एजेंट्स को ज़रूरी जानकारी सुरक्षित रखते हैं।
 
 ```bash
 # Without Boost: ~9,800 tokens of install noise
@@ -114,20 +114,20 @@ $ boost npm ci
 [OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
 ```
 
-एजेंट स्क्रॉलबैक नहीं, उपयोगी सारांश देखता है। विफलताओं पर, Boost वह विफल टेस्ट, कंपाइलर त्रुटि, या स्टैक फ्रेम रखता है जो मायने रखता है।
+एजेंट को स्क्रॉलबैक के बजाय उपयोगी सारांश दिखता है। कमांड फेल होने पर Boost वही फेल हुआ टेस्ट, कम्पाइलर एरर या स्टैक फ़्रेम बनाए रखता है जो मायने रखता है।
 
 ## [Boost कैसे अलग है](https://boost.jfrog.com/docs/en/why-boost/)
 
 | क्षमता | Boost | RTK | Headroom | Caveman |
 | --- | :---: | :---: | :---: | :---: |
-| कमांड आउटपुट संपीड़न | ✓ | ✓ | ✓ | × |
-| पूर्ण-कॉन्टेक्स्ट और RAG संपीड़न | × | × | ✓ | × |
-| सहायक उत्तर संपीड़न | × | × | × | ✓ |
-| कमांड आउटपुट पुनर्प्राप्ति | ✓ | ✓ | ✓ | × |
-| नेटिव अनुमोदन मूल एक्ज़ीक्यूटेबल देखता है | ✓ | × | — | — |
-| वर्शन्ड पुनर्प्राप्ति फ़ीडबैक | ✓ | × | × | × |
-| बार-बार पुनर्प्राप्त फ़िल्टर स्वतः अक्षम करें | ✓ | × | × | × |
-| एंड-टू-एंड एजेंट टास्क + लागत A/B | ✓ | × | × | × |
+| कमांड आउटपुट कम्प्रेशन | ✓ | ✓ | ✓ | × |
+| फ़ुल-कॉन्टेक्स्ट और RAG कम्प्रेशन | × | × | ✓ | × |
+| असिस्टेंट के जवाब का कम्प्रेशन | × | × | × | ✓ |
+| कमांड आउटपुट रिकवरी | ✓ | ✓ | ✓ | × |
+| नेटिव अप्रूवल में मूल एक्ज़ीक्यूटेबल दिखाई देता है | ✓ | × | — | — |
+| वर्ज़न्ड रिट्रीवल फ़ीडबैक | ✓ | × | × | × |
+| बार-बार रिट्रीव किए गए फ़िल्टर्स को अपने-आप डिसेबल करना | ✓ | × | × | × |
+| एंड-टू-एंड एजेंट टास्क + लागत का A/B टेस्ट | ✓ | × | × | × |
 
 ## अपनी बचत देखें
 
@@ -137,23 +137,23 @@ $ boost npm ci
 boost report
 ```
 
-टर्मिनल नैरेटिव सारांश के लिए:
+टर्मिनल में नैरेटिव समरी के लिए:
 
 ```bash
 boost report -t
 # or: boost report --tui
 ```
 
-## यह क्या रैप करता है
+## Boost क्या रैप करता है
 
 - **एजेंट्स:** Cursor, Claude Code, GitHub Copilot, Codex CLI।
-- **कमांड:** Docker, npm, pytest, Git, GitHub CLI, और अन्य शेल कमांड उसी रैपर से गुज़रते हैं।
+- **कमांड्स:** Docker, npm, pytest, Git, GitHub CLI और दूसरे शेल कमांड्स इसी रैपर से गुज़रते हैं।
 
-## आपके एजेंट Boost कैसे उपयोग करते हैं
+## आपके एजेंट Boost का इस्तेमाल कैसे कर रहे हैं
 
-- `boost docker build ...` — संपीड़ित बिल्ड लॉग और लेयर-कैश सारांश
-- `boost npm ci` — निर्भरता सारांश, स्थानीय पैकेज कैश, पुनः प्रयास-सुरक्षित आउटपुट
-- `boost pytest` — हरी रन पर शांत आउटपुट, टेस्ट टूटने पर उपयोगी विफलताएँ
+- `boost docker build ...` — कम्प्रेस्ड बिल्ड लॉग और लेयर-कैश समरी
+- `boost npm ci` — डिपेंडेंसी समरी, लोकल पैकेज कैश और रीट्राई-सेफ़ आउटपुट
+- `boost pytest` — सफल रन में कम आउटपुट और टेस्ट फेल होने पर उपयोगी विफलता विवरण
 
 ## अपडेट
 
@@ -161,17 +161,17 @@ boost report -t
 boost update
 ```
 
-## दस्तावेज़ीकरण
+## डॉक्यूमेंटेशन
 
-कमांड, कॉन्फ़िगरेशन और OpenTelemetry एक्सपोर्ट के लिए [पूर्ण दस्तावेज़ीकरण](https://boost.jfrog.com/docs/en/overview/) देखें।
+कमांड, कॉन्फ़िगरेशन और OpenTelemetry एक्सपोर्ट के लिए [पूरी डॉक्यूमेंटेशन](https://boost.jfrog.com/docs/en/overview/) देखें।
 
 ## सुरक्षा और गोपनीयता
 
-- **लोकल-फर्स्ट।** कमांड इतिहास और कच्चे लॉग आपकी मशीन पर रहते हैं।
-- **केवल मेटाडेटा बाहर जाता है।** जब Boost उपयोग डेटा भेजता है, तो वह उत्पाद सुधारने में मदद के लिए केवल JFrog को जाता है। निर्यात किए गए मेटाडेटा में समय, एग्ज़िट कोड और कैश आँकड़े शामिल हैं — कभी कच्चे लॉग, फ़ाइल सामग्री या एन्व मान नहीं। `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` जैसे पैटर्न से मेल खाने वाले सीक्रेट्स लेखन या निर्यात से पहले रिडैक्ट कर दिए जाते हैं।
-- **ओपन प्रोटोकॉल, हस्ताक्षरित बाइनरी।** OpenTelemetry-नेटिव। बाइनरी GitHub Releases के माध्यम से हस्ताक्षरित होकर आती हैं।
+- **लोकल-फर्स्ट।** कमांड हिस्ट्री और रॉ लॉग्स आपकी मशीन पर ही रहते हैं।
+- **सिर्फ़ मेटाडेटा बाहर भेजा जाता है।** जब Boost उपयोग से जुड़ा डेटा भेजता है, तो वह प्रोडक्ट को बेहतर बनाने के लिए सिर्फ़ JFrog को भेजा जाता है। एक्सपोर्ट किए गए मेटाडेटा में टाइमिंग, एग्ज़िट कोड और कैश आँकड़े शामिल होते हैं; रॉ लॉग्स, फ़ाइलों की सामग्री या एनवायरनमेंट वैरिएबल्स की वैल्यूज़ कभी शामिल नहीं होतीं। `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` जैसे पैटर्न से मेल खाने वाले सीक्रेट्स को सहेजने या एक्सपोर्ट करने से पहले रीडैक्ट कर दिया जाता है।
+- **ओपन प्रोटोकॉल, हस्ताक्षरित बाइनरी।** OpenTelemetry-नेटिव। साइन की गई बाइनरीज़ GitHub Releases के ज़रिए उपलब्ध कराई जाती हैं।
 
-पूर्ण नीति, समर्थित संस्करण, और भेद्यता की रिपोर्ट कैसे करें: [SECURITY.md](./SECURITY.md) देखें।
+पूरी पॉलिसी, सपोर्टेड वर्ज़न्स और किसी वल्नरेबिलिटी को रिपोर्ट करने के तरीके के लिए [SECURITY.md](./SECURITY.md) देखें।
 
 ## लाइसेंस
 
@@ -179,4 +179,4 @@ Copyright © 2026 JFrog Ltd. सर्वाधिकार सुरक्ष�
 
 ---
 
-*Dima Gershovich की स्मृति को समर्पित — एक प्रतिभाशाली इंजीनियर, एक प्रतिभाशाली संगीतकार, और एक प्रिय मित्र।* [Dima की कहानी पढ़ें](docs/memorial/MEMORIAL.md)
+*Dima Gershovich की याद में — एक बेहतरीन इंजीनियर, प्रतिभाशाली संगीतकार और प्रिय मित्र।* [Dima की कहानी पढ़ें](docs/memorial/MEMORIAL.md)

--- a/README.hi.md
+++ b/README.hi.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <strong>टोकन बचाएँ। कॉन्टेक्स्ट का अधिकतम उपयोग करें।</strong>
+  <strong>टोकन बचाएँ। एजेंट्स को ज़्यादा सटीक बनाएँ।</strong>
 </p>
 
 <p align="center">

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,182 @@
+<p align="center">
+  <a href="https://boost.jfrog.com/">
+    <picture>
+      <source srcset=".github/assets/boost-logo-dark.png" media="(prefers-color-scheme: dark)">
+      <source srcset=".github/assets/boost-logo-light.png" media="(prefers-color-scheme: light)">
+      <img src=".github/assets/boost-logo-light.png" alt="Boost" width="260">
+    </picture>
+  </a>
+</p>
+
+<p align="center">
+  <strong>トークンを節約。コンテキストを最大化。</strong>
+</p>
+
+<p align="center">
+  <sub>コーディングエージェントとシェルコマンドのためのスマートなトークン節約。</sub>
+</p>
+
+<p align="center">
+  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
+  <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+</p>
+
+<p align="center">
+  <sub>スポンサー: <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <strong>日本語</strong> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.he.md">עברית</a>
+</p>
+
+---
+
+<p align="center">
+  <strong>マスコットの Frogi は、<code>boost</code> だけを実行すると現れます。</strong>
+</p>
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+  </picture>
+</p>
+
+**Boost** は、エージェントがすでに実行しているコマンドをラップし、ノイズの多いログを、エラー・タイミング・変更数・キャッシュヒットというシグナルを保ちつつノイズを削減した、コンパクトで構造化されたコンテキストに変えます。
+
+Boost は節約のために品質を犠牲にしません。安全に削除できるものだけを削るので、エージェントの出力は同じように鋭いままです。[Terminal-Bench 2.0 ベンチマーク](https://boost.jfrog.com/blog/benchmarks-terminal-bench/)がそれを示しています。タスクの成功率は同じで、コストは約 12% 低下 — Boost はエージェントの歩みを崩すことなく最適化を保ちます。
+
+<p align="center">
+  <picture>
+    <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
+    <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+  </picture>
+</p>
+
+## クイックスタート
+
+**Boost をインストール**
+
+macOS / Linux / Windows WSL:
+
+```bash
+curl -fsSL https://boost.jfrog.com/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://boost.jfrog.com/install.ps1 | iex
+```
+
+**Cursor、Claude Code、GitHub Copilot、Codex CLI に接続:**
+
+```bash
+boost init
+```
+
+ユーザーのマシンに Boost をインストールする AI コーディングエージェント向けには、**[AGENT-INSTALL.md](./AGENT-INSTALL.md)** に従ってください。
+
+## Boost を使うタイミング
+
+- **長いコーディングエージェントセッション** — 数十のシェルコマンドにわたってコンテキストをスリムに保ち、エージェントがスクロールバックではなくタスクにトークンを使えるようにします。
+- **ノイズの多いテスト・ビルド・デバッグのループ** — `npm test`、`pytest`、`go test`、`docker build`、リンター、ログを圧縮しつつ、失敗と要約は保持します。
+- **CI パイプライン** — GitHub Actions やその他のランナー向けに、タイミングとキャッシュのシグナル付きで、短く読みやすいジョブログを提供します。
+- **カスタムまたは社内ツール** — 独自 CLI 向けの TOML フィルタを追加し、エージェントが実際に使うツールにも同じ圧縮ループを適用します。
+
+## スマートなトークン節約
+
+Boost は出力を単に切り詰めるだけではありません。結果についてエージェントが推論するために必要なものを保つ、コマンド対応のフィルタを適用します。
+
+```bash
+# Without Boost: ~9,800 tokens of install noise
+$ npm ci
+npm warn deprecated inflight@1.0.6 / rimraf@3.0.2 / glob@7.2.3 …
+added 1285 packages, audited 1286 in 45s
+found 0 vulnerabilities
+
+# With Boost: ~640 tokens, same outcome, cache-backed
+$ boost npm ci
+[OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
+```
+
+エージェントはスクロールバックではなく、有用な要約を見ます。失敗時には、Boost は失敗したテスト、コンパイラエラー、または重要なスタックフレームを保持します。
+
+## [Boost の違い](https://boost.jfrog.com/docs/en/why-boost/)
+
+| 機能 | Boost | RTK | Headroom | Caveman |
+| --- | :---: | :---: | :---: | :---: |
+| コマンド出力の圧縮 | ✓ | ✓ | ✓ | × |
+| フルコンテキストと RAG の圧縮 | × | × | ✓ | × |
+| アシスタント応答の圧縮 | × | × | × | ✓ |
+| コマンド出力の復元 | ✓ | ✓ | ✓ | × |
+| ネイティブ承認が元の実行ファイルを見る | ✓ | × | — | — |
+| バージョン付き検索フィードバック | ✓ | × | × | × |
+| 繰り返し復元されたフィルタの自動無効化 | ✓ | × | × | × |
+| エージェントタスク + コストのエンドツーエンド A/B | ✓ | × | × | × |
+
+## 節約を確認する
+
+コマンドをラップしたあと、対話型の Web レポートを開きます。
+
+```bash
+boost report
+```
+
+ターミナルでのナラティブ要約の場合:
+
+```bash
+boost report -t
+# or: boost report --tui
+```
+
+## ラップ対象
+
+- **エージェント:** Cursor、Claude Code、GitHub Copilot、Codex CLI。
+- **コマンド:** Docker、npm、pytest、Git、GitHub CLI、およびその他のシェルコマンドが同じラッパーを通ります。
+
+## エージェントが Boost を使う様子
+
+- `boost docker build ...` — 圧縮されたビルドログとレイヤーキャッシュの要約
+- `boost npm ci` — 依存関係の要約、ローカルパッケージキャッシュ、再試行に安全な出力
+- `boost pytest` — 成功時は静かな出力、テスト失敗時は有用な失敗情報
+
+## 更新
+
+```bash
+boost update
+```
+
+## ドキュメント
+
+コマンド、設定、OpenTelemetry エクスポートについては、[完全なドキュメント](https://boost.jfrog.com/docs/en/overview/)を参照してください。
+
+## セキュリティとプライバシー
+
+- **ローカル優先。** コマンド履歴と生のログはマシン上に残ります。
+- **出ていくのはメタデータのみ。** Boost が使用データを送信する場合、製品改善のために JFrog にのみ送られます。エクスポートされるメタデータにはタイミング、終了コード、キャッシュ統計が含まれ、生のログ、ファイル内容、環境変数の値は含まれません。`*_TOKEN`、`*_SECRET`、`AWS_*`、`DATABASE_URL` などのパターンに一致するシークレットは、書き込みまたはエクスポートの前に編集されます。
+- **オープンプロトコル、署名付きバイナリ。** OpenTelemetry ネイティブ。バイナリは GitHub Releases 経由で署名されて配布されます。
+
+完全なポリシー、サポートされるバージョン、脆弱性の報告方法: [SECURITY.md](./SECURITY.md) を参照してください。
+
+## ライセンス
+
+Copyright © 2026 JFrog Ltd. All rights reserved. [LICENSE](LICENSE) および [BETA_AGREEMENT.md](BETA_AGREEMENT.md) を参照してください。
+
+---
+
+*Dima Gershovich の思い出に捧ぐ — 優れたエンジニア、才能ある音楽家、そして親愛なる友人。* [Dima の物語を読む](docs/memorial/MEMORIAL.md)

--- a/README.ja.md
+++ b/README.ja.md
@@ -13,17 +13,17 @@
 </p>
 
 <p align="center">
-  <sub>コーディングエージェントとシェルコマンドのためのスマートなトークン節約。</sub>
+  <sub>コーディングエージェントとシェルコマンドのトークン使用量を賢く削減。</sub>
 </p>
 
 <p align="center">
-  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Website"></a>
-  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="Release"></a>
+  <a href="https://boost.jfrog.com/"><img src="https://img.shields.io/badge/website-boost.jfrog.com-36a13b?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI%2BPHBhdGggZmlsbD0iIzlCRTE1RCIgZD0iTTkuMiAxLjUgMy4xIDkuMmgzLjlsLTEuMSA1LjMgNy4xLTguMkg5LjV6Ii8%2BPC9zdmc%2B" alt="Web サイト"></a>
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/v/release/jfrog/boost?color=36a13b" alt="リリース"></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25"></a>
-  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platforms">
-  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
-  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
-  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="対応プラットフォーム">
+  <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="ダウンロード数"></a>
+  <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="GitHub スター数"></a><br>
+  <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="エージェントネイティブ">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
 </p>
 
@@ -44,26 +44,26 @@
 ---
 
 <p align="center">
-  <strong>マスコットの Frogi は、<code>boost</code> だけを実行すると現れます。</strong>
+  <strong>マスコットの Frogi は、<code>boost</code> コマンドを単独で実行すると現れます。</strong>
 </p>
 
 <p align="center">
   <picture>
     <source srcset=".github/assets/boost-mascot-dark.png" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-mascot-light.png" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-mascot-light.png" alt="Frogi, the Boost mascot" width="180">
+    <img src=".github/assets/boost-mascot-light.png" alt="Boost のマスコット Frogi" width="180">
   </picture>
 </p>
 
-**Boost** は、エージェントがすでに実行しているコマンドをラップし、ノイズの多いログを、エラー・タイミング・変更数・キャッシュヒットというシグナルを保ちつつノイズを削減した、コンパクトで構造化されたコンテキストに変えます。
+**Boost** は、エージェントがすでに実行しているコマンドをラップし、ノイズの多いログから不要な情報を削りつつ、エラー、所要時間、変更件数、キャッシュヒットといった重要な情報を残して、コンパクトで構造化されたコンテキストに変換します。
 
-Boost は節約のために品質を犠牲にしません。安全に削除できるものだけを削るので、エージェントの出力は同じように鋭いままです。[Terminal-Bench 2.0 ベンチマーク](https://boost.jfrog.com/blog/benchmarks-terminal-bench/)がそれを示しています。タスクの成功率は同じで、コストは約 12% 低下 — Boost はエージェントの歩みを崩すことなく最適化を保ちます。
+Boost はトークン節約のために品質を犠牲にしません。安全に省ける情報だけを削るため、エージェントの出力品質は変わりません。[Terminal-Bench 2.0 ベンチマーク](https://boost.jfrog.com/blog/benchmarks-terminal-bench/)がそれを実証しています。タスク成功率は同一で、コストは約 12% 低下しています。Boost はエージェントの動作を妨げることなく、その効率を高く保ちます。
 
 <p align="center">
   <picture>
     <source srcset=".github/assets/boost-how-to-use-dark.gif" media="(prefers-color-scheme: dark)">
     <source srcset=".github/assets/boost-how-to-use-light.gif" media="(prefers-color-scheme: light)">
-    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost how to use: install, boost init, run a task, boost report" width="768">
+    <img src=".github/assets/boost-how-to-use-light.gif" alt="Boost の使い方: インストール、boost init、タスクの実行、boost report" width="768">
   </picture>
 </p>
 
@@ -83,24 +83,24 @@ Windows PowerShell:
 irm https://boost.jfrog.com/install.ps1 | iex
 ```
 
-**Cursor、Claude Code、GitHub Copilot、Codex CLI に接続:**
+**Cursor、Claude Code、GitHub Copilot、Codex CLI で Boost を使えるように設定:**
 
 ```bash
 boost init
 ```
 
-ユーザーのマシンに Boost をインストールする AI コーディングエージェント向けには、**[AGENT-INSTALL.md](./AGENT-INSTALL.md)** に従ってください。
+AI コーディングエージェントがユーザーのマシンに Boost をインストールする場合は、**[AGENT-INSTALL.md](./AGENT-INSTALL.md)** に従ってください。
 
 ## Boost を使うタイミング
 
-- **長いコーディングエージェントセッション** — 数十のシェルコマンドにわたってコンテキストをスリムに保ち、エージェントがスクロールバックではなくタスクにトークンを使えるようにします。
-- **ノイズの多いテスト・ビルド・デバッグのループ** — `npm test`、`pytest`、`go test`、`docker build`、リンター、ログを圧縮しつつ、失敗と要約は保持します。
-- **CI パイプライン** — GitHub Actions やその他のランナー向けに、タイミングとキャッシュのシグナル付きで、短く読みやすいジョブログを提供します。
-- **カスタムまたは社内ツール** — 独自 CLI 向けの TOML フィルタを追加し、エージェントが実際に使うツールにも同じ圧縮ループを適用します。
+- **長時間のコーディングエージェントセッション** — 数十回に及ぶシェルコマンドの実行中もコンテキストを簡潔に保ち、エージェントがスクロールバックではなくタスクにトークンを使えるようにします。
+- **ノイズの多いテスト・ビルド・デバッグのループ** — `npm test`、`pytest`、`go test`、`docker build`、リンター、ログを圧縮しつつ、エラー情報とサマリーは保持します。
+- **CI パイプライン** — GitHub Actions やその他のランナー向けに、実行時間とキャッシュ状況を残した、短く確認しやすいジョブログにします。
+- **カスタムまたは社内ツール** — 独自 CLI 向けの TOML フィルタを追加し、エージェントが実際に使うツールも同じ圧縮処理の対象にします。
 
-## スマートなトークン節約
+## トークンを賢く節約
 
-Boost は出力を単に切り詰めるだけではありません。結果についてエージェントが推論するために必要なものを保つ、コマンド対応のフィルタを適用します。
+Boost は出力を単に切り詰めるだけではありません。コマンドを認識するフィルタを適用し、エージェントが結果を判断するために必要な情報を保持します。
 
 ```bash
 # Without Boost: ~9,800 tokens of install noise
@@ -114,9 +114,9 @@ $ boost npm ci
 [OK] npm ci · 1,285 packages restored from boost cache in 2.4s · 0 vulnerabilities
 ```
 
-エージェントはスクロールバックではなく、有用な要約を見ます。失敗時には、Boost は失敗したテスト、コンパイラエラー、または重要なスタックフレームを保持します。
+エージェントに届くのは、端末の過去出力ではなく有用なサマリーです。失敗時には、Boost は失敗したテスト、コンパイラエラー、または重要なスタックフレームを保持します。
 
-## [Boost の違い](https://boost.jfrog.com/docs/en/why-boost/)
+## [Boost が他と異なる点](https://boost.jfrog.com/docs/en/why-boost/)
 
 | 機能 | Boost | RTK | Headroom | Caveman |
 | --- | :---: | :---: | :---: | :---: |
@@ -124,20 +124,20 @@ $ boost npm ci
 | フルコンテキストと RAG の圧縮 | × | × | ✓ | × |
 | アシスタント応答の圧縮 | × | × | × | ✓ |
 | コマンド出力の復元 | ✓ | ✓ | ✓ | × |
-| ネイティブ承認が元の実行ファイルを見る | ✓ | × | — | — |
-| バージョン付き検索フィードバック | ✓ | × | × | × |
+| ネイティブ承認で元の実行コマンドを確認可能 | ✓ | × | — | — |
+| バージョン情報付きの復元フィードバック | ✓ | × | × | × |
 | 繰り返し復元されたフィルタの自動無効化 | ✓ | × | × | × |
-| エージェントタスク + コストのエンドツーエンド A/B | ✓ | × | × | × |
+| エージェントのタスクとコストを対象としたエンドツーエンド A/B 比較 | ✓ | × | × | × |
 
-## 節約を確認する
+## 削減効果を確認する
 
-コマンドをラップしたあと、対話型の Web レポートを開きます。
+コマンドをラップした後、対話型 Web レポートを開くには:
 
 ```bash
 boost report
 ```
 
-ターミナルでのナラティブ要約の場合:
+ターミナルで文章形式の要約を表示するには:
 
 ```bash
 boost report -t
@@ -149,11 +149,11 @@ boost report -t
 - **エージェント:** Cursor、Claude Code、GitHub Copilot、Codex CLI。
 - **コマンド:** Docker、npm、pytest、Git、GitHub CLI、およびその他のシェルコマンドが同じラッパーを通ります。
 
-## エージェントが Boost を使う様子
+## エージェントによる Boost の使用例
 
 - `boost docker build ...` — 圧縮されたビルドログとレイヤーキャッシュの要約
-- `boost npm ci` — 依存関係の要約、ローカルパッケージキャッシュ、再試行に安全な出力
-- `boost pytest` — 成功時は静かな出力、テスト失敗時は有用な失敗情報
+- `boost npm ci` — 依存関係の要約、ローカルパッケージキャッシュ、再試行しても問題のない出力
+- `boost pytest` — 成功時は簡潔な出力、テスト失敗時は有用なエラー情報
 
 ## 更新
 
@@ -163,15 +163,15 @@ boost update
 
 ## ドキュメント
 
-コマンド、設定、OpenTelemetry エクスポートについては、[完全なドキュメント](https://boost.jfrog.com/docs/en/overview/)を参照してください。
+コマンド、設定、OpenTelemetry エクスポートについては、[詳しいドキュメント](https://boost.jfrog.com/docs/en/overview/)を参照してください。
 
 ## セキュリティとプライバシー
 
-- **ローカル優先。** コマンド履歴と生のログはマシン上に残ります。
-- **出ていくのはメタデータのみ。** Boost が使用データを送信する場合、製品改善のために JFrog にのみ送られます。エクスポートされるメタデータにはタイミング、終了コード、キャッシュ統計が含まれ、生のログ、ファイル内容、環境変数の値は含まれません。`*_TOKEN`、`*_SECRET`、`AWS_*`、`DATABASE_URL` などのパターンに一致するシークレットは、書き込みまたはエクスポートの前に編集されます。
-- **オープンプロトコル、署名付きバイナリ。** OpenTelemetry ネイティブ。バイナリは GitHub Releases 経由で署名されて配布されます。
+- **ローカルファースト。** コマンド履歴と生のログはマシン上に残ります。
+- **外部に送信されるのはメタデータのみ。** Boost が使用状況データを送信する場合、製品改善を目的として JFrog にのみ送信されます。エクスポートされるメタデータにはタイミング情報、終了コード、キャッシュ統計が含まれますが、生のログ、ファイルの内容、環境変数の値は含まれません。`*_TOKEN`、`*_SECRET`、`AWS_*`、`DATABASE_URL` などのパターンに一致するシークレットは、保存またはエクスポートの前に秘匿化されます。
+- **オープンプロトコル、署名付きバイナリ。** OpenTelemetry ネイティブ。署名済みバイナリは GitHub Releases から配布されます。
 
-完全なポリシー、サポートされるバージョン、脆弱性の報告方法: [SECURITY.md](./SECURITY.md) を参照してください。
+ポリシー全文、サポート対象バージョン、脆弱性の報告方法については、[SECURITY.md](./SECURITY.md) を参照してください。
 
 ## ライセンス
 
@@ -179,4 +179,4 @@ Copyright © 2026 JFrog Ltd. All rights reserved. [LICENSE](LICENSE) および [
 
 ---
 
-*Dima Gershovich の思い出に捧ぐ — 優れたエンジニア、才能ある音楽家、そして親愛なる友人。* [Dima の物語を読む](docs/memorial/MEMORIAL.md)
+*卓越したエンジニア、才能あふれる音楽家、そして大切な友人であった Dima Gershovich を偲んで。* [Dima の物語を読む](docs/memorial/MEMORIAL.md)

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <strong>トークンを節約。コンテキストを最大化。</strong>
+  <strong>トークンを節約。エージェントの精度を高める。</strong>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@
   <sub>Sponsored by <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
 </p>
 
+<p align="center">
+  <strong>English</strong> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.de.md">Deutsch</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.hi.md">हिन्दी</a> ·
+  <a href="README.he.md">עברית</a>
+</p>
+
 ---
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <strong>Save tokens. Maximize context.</strong>
+  <strong>Save tokens. Sharpen agents.</strong>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Localize the GitHub repo main page (`README.md`) with translated READMEs for Español, Français, Deutsch, 日本語, हिन्दी, and עברית.
- Add a language selector under the badges on every README so readers can switch languages from the public repo main page.
- Faithful translations of the public English README; code blocks, commands, badges, assets, tool/command names, paths, and URLs stay verbatim.

## Files

- `README.md` — language selector added
- `README.es.md`, `README.fr.md`, `README.de.md`, `README.ja.md`, `README.hi.md`, `README.he.md` — new translations

## Test plan

- [ ] Language selector links resolve to the correct `README.<lang>.md` files on GitHub
- [ ] Tables, code blocks, logo/mascot/GIF assets render in each translation
- [ ] Hebrew (RTL) content renders acceptably on GitHub


Made with [Cursor](https://cursor.com)