### PR TITLE
docs: surface JFrog Xray security scanning in README and SECURITY.md

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -24,9 +24,7 @@
   <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Downloads"></a>
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="GitHub-Sterne"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-nativ">
-  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
-  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="Geprüft von JFrog Xray"></a>
-</p>
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry"></p>
 
 <p align="center">
   <sub>Gesponsert von <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
@@ -40,6 +38,16 @@
   <a href="README.ja.md">日本語</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
   <a href="README.he.md">עברית</a>
+</p>
+
+<p align="center">
+  <a href="./SECURITY.md#security-scanning">
+    <img src="https://img.shields.io/badge/Scanned%20by-JFrog%20Xray-40BE46?style=for-the-badge&logo=jfrog&logoColor=white&labelColor=1F2328" alt="Geprüft von JFrog Xray" height="38">
+  </a>
+</p>
+
+<p align="center">
+  <sub>Abhängigkeiten, Quellcode, Secrets und IaC — bei jedem Push auf <code>main</code> geprüft.</sub>
 </p>
 
 ---

--- a/README.de.md
+++ b/README.de.md
@@ -25,6 +25,7 @@
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="GitHub-Sterne"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-nativ">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="Geprüft von JFrog Xray"></a>
 </p>
 
 <p align="center">

--- a/README.es.md
+++ b/README.es.md
@@ -24,9 +24,7 @@
   <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Descargas"></a>
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Estrellas"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Nativo para agentes">
-  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
-  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="Analizado por JFrog Xray"></a>
-</p>
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry"></p>
 
 <p align="center">
   <sub>Patrocinado por <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
@@ -40,6 +38,16 @@
   <a href="README.ja.md">日本語</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
   <a href="README.he.md">עברית</a>
+</p>
+
+<p align="center">
+  <a href="./SECURITY.md#security-scanning">
+    <img src="https://img.shields.io/badge/Scanned%20by-JFrog%20Xray-40BE46?style=for-the-badge&logo=jfrog&logoColor=white&labelColor=1F2328" alt="Analizado por JFrog Xray" height="38">
+  </a>
+</p>
+
+<p align="center">
+  <sub>Dependencias, código fuente, secretos e IaC: analizados en cada push a <code>main</code>.</sub>
 </p>
 
 ---

--- a/README.es.md
+++ b/README.es.md
@@ -25,6 +25,7 @@
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Estrellas"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Nativo para agentes">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="Analizado por JFrog Xray"></a>
 </p>
 
 <p align="center">

--- a/README.fr.md
+++ b/README.fr.md
@@ -25,6 +25,7 @@
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Étoiles GitHub"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Conçu pour les agents">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="Analysé par JFrog Xray"></a>
 </p>
 
 <p align="center">

--- a/README.fr.md
+++ b/README.fr.md
@@ -24,9 +24,7 @@
   <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="Téléchargements"></a>
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Étoiles GitHub"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Conçu pour les agents">
-  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
-  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="Analysé par JFrog Xray"></a>
-</p>
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry"></p>
 
 <p align="center">
   <sub>Soutenu par <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
@@ -40,6 +38,16 @@
   <a href="README.ja.md">日本語</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
   <a href="README.he.md">עברית</a>
+</p>
+
+<p align="center">
+  <a href="./SECURITY.md#security-scanning">
+    <img src="https://img.shields.io/badge/Scanned%20by-JFrog%20Xray-40BE46?style=for-the-badge&logo=jfrog&logoColor=white&labelColor=1F2328" alt="Analysé par JFrog Xray" height="38">
+  </a>
+</p>
+
+<p align="center">
+  <sub>Dépendances, code source, secrets et IaC : analysés à chaque push sur <code>main</code>.</sub>
 </p>
 
 ---

--- a/README.he.md
+++ b/README.he.md
@@ -25,6 +25,7 @@
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="כוכבים ב-GitHub"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="מותאם לסוכנים">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="נסרק על ידי JFrog Xray"></a>
 </p>
 
 <p align="center" dir="rtl">

--- a/README.he.md
+++ b/README.he.md
@@ -24,9 +24,7 @@
   <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="הורדות"></a>
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="כוכבים ב-GitHub"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="מותאם לסוכנים">
-  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
-  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="נסרק על ידי JFrog Xray"></a>
-</p>
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry"></p>
 
 <p align="center" dir="rtl">
   <sub>בחסות <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
@@ -40,6 +38,16 @@
   <a href="README.ja.md">日本語</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
   <strong>עברית</strong>
+</p>
+
+<p align="center">
+  <a href="./SECURITY.md#security-scanning">
+    <img src="https://img.shields.io/badge/Scanned%20by-JFrog%20Xray-40BE46?style=for-the-badge&logo=jfrog&logoColor=white&labelColor=1F2328" alt="נסרק על ידי JFrog Xray" height="38">
+  </a>
+</p>
+
+<p align="center" dir="rtl">
+  <sub>תלויות, קוד מקור, סודות ותשתית כקוד (IaC) — נסרקים בכל push ל-<code>main</code>.</sub>
 </p>
 
 ---

--- a/README.hi.md
+++ b/README.hi.md
@@ -24,9 +24,7 @@
   <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="डाउनलोड्स"></a>
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="स्टार्स"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="एजेंट-नेटिव">
-  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
-  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="JFrog Xray द्वारा स्कैन किया गया"></a>
-</p>
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry"></p>
 
 <p align="center">
   <sub><a href="https://jfrog.com"><strong>JFrog</strong></a> द्वारा प्रायोजित</sub>
@@ -40,6 +38,16 @@
   <a href="README.ja.md">日本語</a> ·
   <strong>हिन्दी</strong> ·
   <a href="README.he.md">עברית</a>
+</p>
+
+<p align="center">
+  <a href="./SECURITY.md#security-scanning">
+    <img src="https://img.shields.io/badge/Scanned%20by-JFrog%20Xray-40BE46?style=for-the-badge&logo=jfrog&logoColor=white&labelColor=1F2328" alt="JFrog Xray द्वारा स्कैन किया गया" height="38">
+  </a>
+</p>
+
+<p align="center">
+  <sub>डिपेंडेंसी, सोर्स कोड, सीक्रेट्स और IaC — <code>main</code> पर हर push पर स्कैन किए जाते हैं।</sub>
 </p>
 
 ---

--- a/README.hi.md
+++ b/README.hi.md
@@ -25,6 +25,7 @@
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="स्टार्स"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="एजेंट-नेटिव">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="JFrog Xray द्वारा स्कैन किया गया"></a>
 </p>
 
 <p align="center">

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,9 +24,7 @@
   <a href="https://github.com/jfrog/boost/releases"><img src="https://img.shields.io/github/downloads/jfrog/boost/total?color=6f42c1" alt="ダウンロード数"></a>
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="GitHub スター数"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="エージェントネイティブ">
-  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
-  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="JFrog Xray でスキャン済み"></a>
-</p>
+  <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry"></p>
 
 <p align="center">
   <sub>スポンサー: <a href="https://jfrog.com"><strong>JFrog</strong></a></sub>
@@ -40,6 +38,16 @@
   <strong>日本語</strong> ·
   <a href="README.hi.md">हिन्दी</a> ·
   <a href="README.he.md">עברית</a>
+</p>
+
+<p align="center">
+  <a href="./SECURITY.md#security-scanning">
+    <img src="https://img.shields.io/badge/Scanned%20by-JFrog%20Xray-40BE46?style=for-the-badge&logo=jfrog&logoColor=white&labelColor=1F2328" alt="JFrog Xray でスキャン済み" height="38">
+  </a>
+</p>
+
+<p align="center">
+  <sub>依存関係・ソースコード・シークレット・IaC を <code>main</code> への push ごとにスキャンしています。</sub>
 </p>
 
 ---

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,6 +25,7 @@
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="GitHub スター数"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="エージェントネイティブ">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="JFrog Xray でスキャン済み"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
-  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="Scanned by JFrog Xray"></a>
 </p>
 
 <p align="center">
@@ -40,6 +39,16 @@
   <a href="README.ja.md">日本語</a> ·
   <a href="README.hi.md">हिन्दी</a> ·
   <a href="README.he.md">עברית</a>
+</p>
+
+<p align="center">
+  <a href="./SECURITY.md#security-scanning">
+    <img src="https://img.shields.io/badge/Scanned%20by-JFrog%20Xray-40BE46?style=for-the-badge&logo=jfrog&logoColor=white&labelColor=1F2328" alt="Scanned by JFrog Xray" height="38">
+  </a>
+</p>
+
+<p align="center">
+  <sub>Dependencies, source, secrets, and IaC — scanned on every push to <code>main</code>. <a href="#security--privacy">What that covers</a>.</sub>
 </p>
 
 ---
@@ -168,15 +177,7 @@ See the [full documentation](https://boost.jfrog.com/docs/en/overview/) for comm
 
 ## Security & Privacy
 
-<p align="center">
-  <a href="./SECURITY.md#security-scanning">
-    <img src="https://img.shields.io/badge/Scanned%20by-JFrog%20Xray-40BE46?style=for-the-badge&logo=jfrog&logoColor=white&labelColor=1F2328" alt="Scanned by JFrog Xray" height="38">
-  </a>
-</p>
-
-<p align="center">
-  <sub>Boost's source repository is scanned on every push to <code>main</code> — the same commits every release is built from — by <a href="https://github.com/jfrog/frogbot">Frogbot</a>, running JFrog Xray with JFrog Advanced Security.</sub>
-</p>
+Boost's source repository is scanned on every push to `main` — the same commits every release is built from — by [Frogbot](https://github.com/jfrog/frogbot), running JFrog Xray with JFrog Advanced Security.
 
 | | What gets scanned |
 | :---: | --- |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   <a href="https://github.com/jfrog/boost/stargazers"><img src="https://img.shields.io/github/stars/jfrog/boost?style=flat&color=yellow" alt="Stars"></a><br>
   <img src="https://img.shields.io/badge/agent--native-brightgreen" alt="Agent-native">
   <img src="https://img.shields.io/badge/OpenTelemetry-enabled-blueviolet?logo=opentelemetry&logoColor=white" alt="OpenTelemetry">
+  <a href="./SECURITY.md#security-scanning"><img src="https://img.shields.io/badge/scanned%20by-JFrog%20Xray-40BE46?logo=jfrog&logoColor=white" alt="Scanned by JFrog Xray"></a>
 </p>
 
 <p align="center">
@@ -166,6 +167,28 @@ boost update
 See the [full documentation](https://boost.jfrog.com/docs/en/overview/) for commands, configuration, and OpenTelemetry export.
 
 ## Security & Privacy
+
+<p align="center">
+  <a href="./SECURITY.md#security-scanning">
+    <img src="https://img.shields.io/badge/Scanned%20by-JFrog%20Xray-40BE46?style=for-the-badge&logo=jfrog&logoColor=white&labelColor=1F2328" alt="Scanned by JFrog Xray" height="38">
+  </a>
+</p>
+
+<p align="center">
+  <sub>Boost's source repository is scanned on every push to <code>main</code> — the same commits every release is built from — by <a href="https://github.com/jfrog/frogbot">Frogbot</a>, running JFrog Xray with JFrog Advanced Security.</sub>
+</p>
+
+| | What gets scanned |
+| :---: | --- |
+| ✓ | **Dependencies (SCA)** — Go modules and npm trees across every module in the repo, matched against JFrog's vulnerability database |
+| ✓ | **Contextual Analysis** — checks whether a reported CVE is actually reachable from Boost's code, so real risk is not buried in noise |
+| ✓ | **Malicious packages** — dependencies flagged as malicious are caught before they reach a build |
+| ✓ | **Secrets** — every tracked file is scanned for leaked credentials and tokens |
+| ✓ | **Source code (SAST)** — Boost's own Go and TypeScript sources |
+| ✓ | **Infrastructure as Code** — CI workflows and deployment definitions |
+| ✓ | **SBOM** — a component inventory is generated per build target on every scan |
+
+Findings land as code-scanning alerts and automated fix pull requests on the source repository. See [SECURITY.md](./SECURITY.md#security-scanning) for the full scanning and disclosure policy.
 
 - **Local-first.** Command history and raw logs stay on your machine.
 - **Only metadata leaves.** When Boost sends usage data, it goes only to JFrog to help improve the product. Exported metadata includes timing, exit code, and cache stats, never raw logs, file contents, or env values. Secrets matching patterns like `*_TOKEN`, `*_SECRET`, `AWS_*`, `DATABASE_URL` are redacted before write or export.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,6 +74,22 @@ Redaction runs at every point where data is captured, stored, or emitted:
 - **Fail-closed at the export boundary.** The OTel exporter wraps every span in `sanitizedSpan`; an un-sanitized span cannot be reached from a normal export code path.
 - **Zero-copy fast path.** When no pattern matches, the input buffer is returned unmodified — performance does not create an incentive to disable redaction.
 
+## Security Scanning
+
+Boost's source repository is scanned by [Frogbot](https://github.com/jfrog/frogbot) — JFrog's Git security bot — on every push to `main`, which are the same commits release binaries are built from. Frogbot runs against **JFrog Xray** with **JFrog Advanced Security** enabled, and repeats the dependency scan for both `linux/amd64` and `linux/arm64` resolution.
+
+| Scan | Coverage |
+| --- | --- |
+| **Software Composition Analysis (SCA)** | Go modules and every npm workspace in the repository, resolved to a full dependency tree and matched against JFrog's vulnerability database |
+| **Contextual Analysis** | Determines whether a reported CVE is reachable from Boost's code before it is treated as an actionable finding |
+| **Malicious package detection** | Flags dependencies identified as malicious, not merely vulnerable |
+| **Secrets detection** | Scans tracked files for leaked credentials, tokens, and keys |
+| **Static Application Security Testing (SAST)** | Boost's own Go and TypeScript sources |
+| **Infrastructure as Code (IaC)** | CI workflows and deployment definitions |
+| **SBOM generation** | A component inventory is produced per build target on every scan |
+
+Results are uploaded as GitHub code-scanning alerts, and Frogbot opens fix pull requests for upgradable vulnerable dependencies. Security findings fail the scan job, so they are triaged rather than silently accumulated. Issues affecting released binaries follow the disclosure process described above.
+
 ## Supply Chain
 
 - **Signed releases.** Binaries are published on [GitHub Releases](https://github.com/jfrog/boost/releases) with checksums.
@@ -99,4 +115,4 @@ The following are outside the scope of this policy:
 
 ---
 
-_Last updated: 2026-04-21_
+_Last updated: 2026-08-11_


### PR DESCRIPTION
## Summary

Boost's source repository is scanned by [Frogbot](https://github.com/jfrog/frogbot) — JFrog Xray with JFrog Advanced Security — on every push to `main`, the same commits releases are built from. None of that was visible to anyone reading the public repo. This PR surfaces it, without overclaiming.

- **Badge up top** — a large `Scanned by JFrog Xray` badge sits directly under the language switcher in all 7 READMEs (English + 6 translations), with a one-line summary of what is scanned, linking to the policy.
- **README.md** — a checkmark table in *Security & Privacy* spelling out the coverage.
- **SECURITY.md** — a new **Security Scanning** section detailing each scanner, the cadence, and where findings land.

## Scan coverage claimed

Every row below was verified against a real Frogbot job log on `main` (`frogbot 2.35.1`, Xray `3.152.0`, Analyzer Manager `1.44.0`), not from the docs:

| Scan | Evidence in the job log |
| --- | --- |
| SCA | `Running SCA scan on target …` × 9 targets (Go modules + every npm workspace) |
| Contextual Analysis | `Running Contextual Analysis scan on target …`, `ca` binary loaded |
| Malicious packages | `mal` binary loaded by the JAS scanner |
| Secrets | `Running Secrets scan on target …` × 9 |
| SAST | `Running SAST scan on target …` × 9 |
| IaC | `Running IaC scan on target …` × 9 |
| SBOM | `Generating SBOM for target …` per build target |

No claim is made about the *results* of any scan (e.g. "0 vulnerabilities"), only about what is scanned and how findings are handled — so the copy stays true as findings come and go.

## Notes

- The badge uses `style=for-the-badge` with the `jfrog` shields logo on a dark label; the URL was checked and returns `200` with the logo embedded.
- The `#security-scanning` anchor matches the new `## Security Scanning` heading in `SECURITY.md`.
- Translated READMEs get the badge with translated alt text and caption, linking to the English `SECURITY.md`. Translating the coverage table itself is a reasonable follow-up if we want full parity.

## Test plan

- [ ] Confirm the badge renders under the language switcher (light and dark themes)
- [ ] Confirm the badge links resolve to `SECURITY.md#security-scanning`
- [ ] Confirm the RTL caption in `README.he.md` reads correctly
